### PR TITLE
Add devd rules for bluetooth devices

### DIFF
--- a/etc/devd/Makefile
+++ b/etc/devd/Makefile
@@ -4,6 +4,8 @@
 
 FILEGROUPS=	FILES
 
+FILES+= bluetooth.conf
+
 .if ${MACHINE} == "powerpc"
 FILES+=	apple.conf
 .endif

--- a/etc/devd/bluetooth.conf
+++ b/etc/devd/bluetooth.conf
@@ -1,0 +1,9 @@
+# When a USB Bluetooth dongle is detected, restart the bluetooth service
+attach 100 {
+	device-name "ubt[0-9]+";
+	action "/sbin/service bluetooth restart";
+};
+detach 100 {
+	device-name "ubt[0-9]+";
+	action "/sbin/service bluetooth restart";
+};


### PR DESCRIPTION
This will properly enable/disable bluetooth devices as they are attached/detached (verified working)