### PR TITLE
add detach to vga_pci

### DIFF
--- a/sys/dev/pci/vga_pci.c
+++ b/sys/dev/pci/vga_pci.c
@@ -283,6 +283,16 @@ vga_pci_suspend(device_t dev)
 }
 
 static int
+vga_pci_detach(device_t dev)
+{
+	int rc;
+
+	if ((rc = bus_generic_detach(dev)) == 0)
+		rc = device_delete_children(dev);
+	return (rc);
+}
+
+static int
 vga_pci_resume(device_t dev)
 {
 
@@ -620,6 +630,7 @@ static device_method_t vga_pci_methods[] = {
 	DEVMETHOD(device_attach,	vga_pci_attach),
 	DEVMETHOD(device_shutdown,	bus_generic_shutdown),
 	DEVMETHOD(device_suspend,	vga_pci_suspend),
+	DEVMETHOD(device_detach,	vga_pci_detach),
 	DEVMETHOD(device_resume,	vga_pci_resume),
 
 	/* Bus interface */


### PR DESCRIPTION
Fix devctl detach to work with vga devices. This is required to make GPU passthrough work when not setting pptdevs in /boot/loader.conf