### PR TITLE
fix NIS startup scripts for ypbind and ypset with missing net-online

### DIFF
--- a/etc/init.d/ypbind
+++ b/etc/init.d/ypbind
@@ -8,12 +8,30 @@ command_args="${nis_client_flags}"
 
 depend()
 {
-	need localmount net
+	after modules
+	need localmount net rpcbind
 	keyword -shutdown -stop
 }
 
 start_pre()
 {
+
+# wait for network to be available
+# Previously this check has been provided by the net-online service, which has
+# been removed in TrueOS-18.03.
+# To avoid breakage of NIS in the future, we perform this check directly here
+
+	local infinite
+
+	timeout=${timeout:-60}
+	ebegin "ypbind waiting for network to become available"
+	[ "$timeout" -eq 0 ] && infinite=true || infinite=false
+	while $infinite || [ "$timeout" -gt 0 ]; do
+		nc -uz 0.0.0.255 111 && break
+		sleep 1
+		: $((timeout -= 1))
+	done
+
 	local _domain
 
 	_domain=`domainname`

--- a/etc/init.d/ypset
+++ b/etc/init.d/ypset
@@ -23,3 +23,11 @@ start_pre()
 		return 1
 	fi
 }
+# without a dedicated (even if empty!) start() block, ypset is reported as crashed.
+# This is most likely a bug in OpenRC, so this ugly workaround should be removed ASAP
+start()
+{
+	ebegin "starting ypset"
+	${command} ${command_args}
+	return 0
+}


### PR DESCRIPTION
/etc/init.d/ypbind:
ypbind needs an active interface to bind to or service startup will silently
fail. The check for this was initially performed by the net-online
pseudo-service, which was removed in TrueOS-18.03

To avoid future breakage the ypbind startup script now performs this
check directly (trying to send to a broadcast address)

/etc/init.d/ypset:
If no start() block is given (even if empty), OpenRC reports ypset as
crashed. Same was/is true for e.g. openntpd and possibly other services
which usually don't run in the background but exit after making their
changes to the system (like ntp setting the system time at startup or ypset
updating ypbind settings).