### PR TITLE
Do not enable nisdomain in boot runlevel by default

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -27,7 +27,6 @@ OPENRC_BOOT_LINK=	abi \
 			motd \
 			network \
 			newsyslog \
-			nisdomain \
 			root \
 			routing \
 			savecore \


### PR DESCRIPTION
* This will enable security warnings on VPS providers, and should probably not be a default.