### PR TITLE
Remove trackpad support by default

### DIFF
--- a/stand/defaults/loader.conf
+++ b/stand/defaults/loader.conf
@@ -222,11 +222,5 @@ loader_brand="trueos"
 loader_logo="trueos"
 loader_menu_title="Welcome to TrueOS"
 
-# Enable Synaptics for touchpads
-hw.psm.synaptics_support="1"
-
-# Enable Elantech touchpad support
-hw.psm.elantech_support="1"
-
 # Speed up boot time
 autoboot_delay="02"


### PR DESCRIPTION
* This should be enabled per appliance using ports not by TrueOS.