### PR TITLE
Add the capability for bhyve to change smbios table type1 using an ucl config file.

### DIFF
--- a/usr.sbin/bhyve/Makefile
+++ b/usr.sbin/bhyve/Makefile
@@ -23,6 +23,7 @@ SRCS=	\
 	bhyverun.c		\
 	block_if.c		\
 	bootrom.c		\
+	config.c		\
 	console.c		\
 	consport.c		\
 	ctl_util.c		\
@@ -74,7 +75,7 @@ SRCS=	\
 .PATH:  ${BHYVE_SYSDIR}/sys/amd64/vmm
 SRCS+=	vmm_instruction_emul.c
 
-LIBADD=	vmmapi md pthread z util sbuf cam
+LIBADD=	vmmapi md pthread ucl z util sbuf cam
 
 .if ${MK_OPENSSL} == "no"
 CFLAGS+=-DNO_OPENSSL
@@ -85,6 +86,7 @@ LIBADD+=	crypto
 CFLAGS+= -I${BHYVE_SYSDIR}/sys/dev/e1000
 CFLAGS+= -I${BHYVE_SYSDIR}/sys/dev/mii
 CFLAGS+= -I${BHYVE_SYSDIR}/sys/dev/usb/controller
+CFLAGS+= -I${SRCTOP}/contrib/libucl/include
 
 .ifdef GDB_LOG
 CFLAGS+=-DGDB_LOG

--- a/usr.sbin/bhyve/bhyve.8
+++ b/usr.sbin/bhyve/bhyve.8
@@ -24,7 +24,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd May 1, 2018
+.Dd May 17, 2018
 .Dt BHYVE 8
 .Os
 .Sh NAME
@@ -87,6 +87,11 @@ Enable a low-level console device supported by
 kernels compiled with
 .Cd "device bvmconsole" .
 This option will be deprecated in a future version.
+.It Fl B
+Load an
+.Cd "libucl"
+configuration file capable to modify the attributes in
+smbios table type1.
 .It Fl c Op Ar setting ...
 Number of guest virtual CPUs
 and/or the CPU topology.

--- a/usr.sbin/bhyve/bhyverun.c
+++ b/usr.sbin/bhyve/bhyverun.c
@@ -68,6 +68,7 @@ __FBSDID("$FreeBSD$");
 #include "bhyverun.h"
 #include "acpi.h"
 #include "atkbdc.h"
+#include "config.h"
 #include "inout.h"
 #include "dbgport.h"
 #include "fwctl.h"
@@ -141,12 +142,13 @@ usage(int code)
 {
 
         fprintf(stderr,
-		"Usage: %s [-abehuwxACHPSWY]\n"
+		"Usage: %s [-abehuwxABCHPSWY]\n"
 		"       %*s [-c [[cpus=]numcpus][,sockets=n][,cores=n][,threads=n]]\n"
 		"       %*s [-g <gdb port>] [-l <lpc>]\n"
 		"       %*s [-m mem] [-p vcpu:hostcpu] [-s <pci>] [-U uuid] <vm>\n"
 		"       -a: local apic is in xAPIC mode (deprecated)\n"
 		"       -A: create ACPI tables\n"
+		"       -B: load libucl smbios configuration file\n"
 		"       -c: number of cpus and/or topology specification"
 		"       -C: include guest memory in core file\n"
 		"       -e: exit on unhandled I/O access\n"
@@ -913,7 +915,7 @@ main(int argc, char *argv[])
 	rtc_localtime = 1;
 	memflags = 0;
 
-	optstr = "abehuwxACHIPSWYp:g:G:c:s:m:l:U:";
+	optstr = "abehuwxACHIPSWYp:B:g:G:c:s:m:l:U:";
 	while ((c = getopt(argc, argv, optstr)) != -1) {
 		switch (c) {
 		case 'a':
@@ -924,6 +926,9 @@ main(int argc, char *argv[])
 			break;
 		case 'b':
 			bvmcons = 1;
+			break;
+		case 'B':
+			load_smbios_config(optarg);
 			break;
 		case 'p':
                         if (pincpu_parse(optarg) != 0) {

--- a/usr.sbin/bhyve/config.c
+++ b/usr.sbin/bhyve/config.c
@@ -1,0 +1,124 @@
+/*-
+ * Copyright (c) 2015 Allan Jude <allanjude@FreeBSD.org>
+ * Copyright (c) 2015-2018 Marcelo Araujo <araujo@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/types.h>
+
+#include <err.h>
+#include <errno.h>
+#include <sysexits.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "config.h"
+
+/*
+ * Check if the config file exists.
+ */
+int
+check_config_file(const char *smbios_file)
+{
+	FILE *file;
+	if ((file = fopen(smbios_file, "r"))) {
+		fclose(file);
+		return (0);
+	}
+	
+	errx(EX_NOINPUT, "Config file %s not found", smbios_file);
+}
+
+/*
+ * Load smbios config file.
+ */
+void
+load_smbios_config(const char *smbios_file)
+{
+	check_config_file(smbios_file);
+
+	struct ucl_parser *parser = NULL;
+	parser = ucl_parser_new(UCL_PARSER_KEY_LOWERCASE |
+			    UCL_PARSER_NO_IMPLICIT_ARRAYS);
+	if (parser == NULL)
+		errx(1, "Could not allocate ucl parser");
+
+	if (smbios_file != NULL) {
+		if (!ucl_parser_add_file_priority(parser, smbios_file, 5)) {
+			if (errno != ENOENT)
+				errx(EXIT_FAILURE, "Parse error in file %s: %s",
+				    smbios_file, ucl_parser_get_error(parser));
+			ucl_parser_free(parser);
+		}
+	}
+
+	parse_smbios_config(parser);
+}
+
+/*
+ * Parse the smbios configuration file.
+ * We only support changes on table type1.
+ *
+ * XXX: Add support for table type3.
+ */
+int
+parse_smbios_config(struct ucl_parser *p)
+{
+	const ucl_object_t *obj = NULL;
+	ucl_object_iter_t it = NULL;
+	const ucl_object_t *cur;
+	const char *key;
+
+	obj = ucl_parser_get_object(p);
+	ucl_parser_free(p);
+
+	if (obj == NULL || ucl_object_type(obj) != UCL_OBJECT)
+		errx(EXIT_FAILURE, "Invalid configuration format.\n");
+
+	it = ucl_object_iterate_new(obj);
+	while ((cur = ucl_object_iterate_safe(it, true)) != NULL) {
+		key = ucl_object_key(cur);
+		/* smbios table type1 */
+		if (strcasecmp(key, "manufacturer") == 0)
+			smbios_type1_strings[0] = (char *)ucl_object_tostring(cur);
+		if (strcasecmp(key, "product") == 0)
+			smbios_type1_strings[1] = (char *)ucl_object_tostring(cur);
+		if (strcasecmp(key, "version") == 0)
+			smbios_type1_strings[2] = (char *)ucl_object_tostring(cur);
+		if (strcasecmp(key, "serial") == 0)
+			smbios_type1_strings[3] = (char *)ucl_object_tostring(cur);
+		if (strcasecmp(key, "sku") == 0)
+			smbios_type1_strings[4] = (char *)ucl_object_tostring(cur);
+		if (strcasecmp(key, "family") == 0)
+			smbios_type1_strings[5] = (char *)ucl_object_tostring(cur);
+		/* End smbios table type1 */
+	}
+	ucl_object_iterate_free(it);
+
+	return (0);
+}

--- a/usr.sbin/bhyve/config.h
+++ b/usr.sbin/bhyve/config.h
@@ -1,0 +1,35 @@
+/*-
+ * Copyright (c) 2015 Allan Jude <allanjude@FreeBSD.org>
+ * Copyright (c) 2015-2018 Marcelo Araujo <araujo@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <ucl.h>
+
+extern char const *smbios_type1_strings[];
+
+int check_config_file(const char *smbios_file);
+void load_smbios_config(const char *smbios_file);
+int parse_smbios_config(struct ucl_parser *p);

--- a/usr.sbin/bhyve/smbiostbl.c
+++ b/usr.sbin/bhyve/smbiostbl.c
@@ -344,7 +344,7 @@ static int smbios_type1_initializer(struct smbios_structure *template_entry,
     const char **template_strings, char *curaddr, char **endaddr,
     uint16_t *n, uint16_t *size);
 
-const char *smbios_type1_strings[] = {
+char const *smbios_type1_strings[] = {
 	" ",		/* manufacturer string */
 	"BHYVE",	/* product name string */
 	"1.0",		/* version string */


### PR DESCRIPTION
Add on bhyverun a new option '-B' that gives the capability to change the smbios table type1 using an ucl based configuration file, it can easily extend to change table type3 and any other smbios table. 

Ex. bios.conf:
manufacturer="iXsystems Inc."
version="3.0"
product = "M"
serial="1234567890"
family="iX M"

Ex. bhyve:
bhyve -B /z/bios.conf