### PR TITLE
Try to use the pool name specified, don't throw a 1/2/3/.. on the end

### DIFF
--- a/usr.sbin/pc-sysinstall/backend/functions-newfs.sh
+++ b/usr.sbin/pc-sysinstall/backend/functions-newfs.sh
@@ -86,6 +86,18 @@ setup_zfs_filesystem()
     sysctl vfs.zfs.min_auto_ashift=12
   fi
 
+  # Verify this pool isn't already in use
+  zpool list | grep -qw "${ZPOOLNAME}"
+  if [ $? -eq 0 ] ; then
+    exit_err "The poolname: $ZPOOLNAME is already in use locally!"
+  fi
+
+  # Verify this pool isn't lingering on another disk
+  zpool import | grep -qw "${ZPOOLNAME}"
+  if [ $? -eq 0 ] ; then
+    exit_err "The poolname: $ZPOOLNAME is already in use on another disk!"
+  fi
+
   if [ -n "${ZPOOLOPTS}" ] ; then
     echo_log "Creating storage pool ${ZPOOLNAME} with $ZPOOLOPTS"
     rc_halt "zpool create -m none -f ${ZPOOLNAME} ${ZPOOLOPTS}"

--- a/usr.sbin/pc-sysinstall/backend/functions.sh
+++ b/usr.sbin/pc-sysinstall/backend/functions.sh
@@ -293,25 +293,12 @@ get_zpool_name()
     # Need to generate a zpool name for this device
     NUM=`ls ${TMPDIR}/.zpools/ | wc -l | sed 's| ||g'`
 
-    # Is it used in another zpool?
-    while :
-    do
-      # If on the 0 device, drop the 0 alltogether
-      if [ "$NUM" = "0" ] ; then
-        NEWNAME="${BASENAME}"
-      else
-        NEWNAME="${BASENAME}${NUM}"
-      fi
-      zpool list | grep -qw "${NEWNAME}"
-      local chk1=$?
-      if [ $chk1 -eq 1 ] ; then
-        # Check any exported pools also
-        zpool import | grep -qw "${NEWNAME}"
-        chk1=$?
-        if [ $chk1 -eq 1 ] ; then break; fi
-      fi
-      NUM=$((NUM+1))
-    done
+    # If on the 0 device, drop the 0 alltogether
+    if [ "$NUM" = "0" ] ; then
+      NEWNAME="${BASENAME}"
+    else
+      NEWNAME="${BASENAME}${NUM}"
+    fi
 
     # Now save the new tank name
     mkdir -p ${TMPDIR}/.zpools/`dirname $DEVICE`


### PR DESCRIPTION
if the pool if the existing pool is going to be destroyed anyway.

Move error check to later after disks have been wiped, and fail out
if the pool name is still in use on some other attached device.

Fixes: #51