### PR TITLE
Trident branding

### DIFF
--- a/stand/forth/Makefile
+++ b/stand/forth/Makefile
@@ -16,6 +16,7 @@ FILES+=	beastie.4th
 FILES+=	brand.4th
 FILES+=	brand-fbsd.4th
 FILES+=	brand-freenas.4th
+FILES+=	brand-trident.4th
 FILES+=	brand-truenas.4th
 FILES+=	brand-trueos.4th
 FILES+=	check-password.4th

--- a/stand/forth/Makefile
+++ b/stand/forth/Makefile
@@ -28,6 +28,7 @@ FILES+=	loader.4th
 FILES+=	logo-beastie.4th
 FILES+=	logo-beastiebw.4th
 FILES+=	logo-fbsdbw.4th
+FILES+=	logo-trident.4th
 FILES+=	logo-trueos.4th
 FILES+=	logo-orb.4th
 FILES+=	logo-orbbw.4th

--- a/stand/forth/brand-trident.4th
+++ b/stand/forth/brand-trident.4th
@@ -1,0 +1,47 @@
+\ Copyright (c) 2015 Kris Moore <kmoore@FreeBSD.org>
+\ Copyright (c) 2006-2015 Devin Teske <dteske@FreeBSD.org>
+\ All rights reserved.
+\ 
+\ Redistribution and use in source and binary forms, with or without
+\ modification, are permitted provided that the following conditions
+\ are met:
+\ 1. Redistributions of source code must retain the above copyright
+\    notice, this list of conditions and the following disclaimer.
+\ 2. Redistributions in binary form must reproduce the above copyright
+\    notice, this list of conditions and the following disclaimer in the
+\    documentation and/or other materials provided with the distribution.
+\ 
+\ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+\ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+\ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+\ ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+\ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+\ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+\ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+\ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+\ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+\ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+\ SUCH DAMAGE.
+\ 
+\ $FreeBSD$
+
+2 brandX ! 1 brandY ! \ Initialize brand placement defaults
+
+: brand+ ( x y c-addr/u -- x y' )
+	2swap 2dup at-xy 2swap \ position the cursor
+	type \ print to the screen
+	1+ \ increase y for next time we're called
+;
+
+: brand ( x y -- ) \ "Trident" [wide] logo in B/W (7 rows x 42 columns)
+
+	s"     _____     _     _            _       " brand+
+	s"    |_   _| __(_) __| | ___ _ __ | |_     " brand+
+	s"      | || '__| |/ _` |/ _ \ '_ \| __|    " brand+
+	s"      | || |  | | (_| |  __/ | | | |_     " brand+
+	s"      |_||_|  |_|\__,_|\___|_| |_|\__|    " brand+
+	s"                                          " brand+
+                                     
+                                         
+	2drop
+;

--- a/stand/forth/brand-trident.4th
+++ b/stand/forth/brand-trident.4th
@@ -1,3 +1,4 @@
+\ Copyright (c) 2018 Ken Moore <moorekou@gmail.com>
 \ Copyright (c) 2015 Kris Moore <kmoore@FreeBSD.org>
 \ Copyright (c) 2006-2015 Devin Teske <dteske@FreeBSD.org>
 \ All rights reserved.

--- a/stand/forth/logo-trident.4th
+++ b/stand/forth/logo-trident.4th
@@ -1,0 +1,54 @@
+\ Copyright (c) 2003 Scott Long <scottl@FreeBSD.org>
+\ Copyright (c) 2006-2015 Devin Teske <dteske@FreeBSD.org>
+\ Copyright (c) 2015 Kris Moore <kmoore@FreeBSD.org>
+\ All rights reserved.
+\ 
+\ Redistribution and use in source and binary forms, with or without
+\ modification, are permitted provided that the following conditions
+\ are met:
+\ 1. Redistributions of source code must retain the above copyright
+\    notice, this list of conditions and the following disclaimer.
+\ 2. Redistributions in binary form must reproduce the above copyright
+\    notice, this list of conditions and the following disclaimer in the
+\    documentation and/or other materials provided with the distribution.
+\ 
+\ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+\ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+\ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+\ ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+\ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+\ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+\ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+\ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+\ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+\ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+\ SUCH DAMAGE.
+\ 
+\ $FreeBSD$
+
+52 logoX ! 9 logoY ! \ Initialize logo placement defaults
+
+: logo+ ( x y c-addr/u -- x y' )
+	2swap 2dup at-xy 2swap \ position the cursor
+	type \ print to the screen
+	1+ \ increase y for next time we're called
+;
+
+: logo ( x y -- ) \ TODO  in B/W (13 rows x 21 columns)
+
+	s"                  "      logo+
+	s"                  "      logo+
+	s"                  "      logo+
+	s"                  "      logo+
+	s"                  "      logo+
+	s"                  "      logo+
+	s"                     "   logo+
+	s"                     "   logo+
+	s"                     "   logo+
+	s"                     "   logo+
+	s"                     "   logo+
+	s"                     "   logo+
+	s"                     "  logo+
+
+	2drop
+;


### PR DESCRIPTION
Add the two files for branding an install for Project Trident.
* brand-trident.4th
* logo-trident.4th
Also add these files to the list within the Makefile