### PR TITLE
Add a new option for bhyvectl to list the running vms.

### DIFF
--- a/usr.sbin/bhyvectl/bhyvectl.c
+++ b/usr.sbin/bhyvectl/bhyvectl.c
@@ -45,6 +45,7 @@ __FBSDID("$FreeBSD$");
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
+#include <sysexits.h>
 #include <unistd.h>
 #include <libgen.h>
 #include <libutil.h>
@@ -1647,12 +1648,12 @@ list_vm(char *vmname)
 			if (dir->d_type != DT_DIR) {
 				ctx = vm_open(dir->d_name);
 				if (ctx == NULL)
-					errx(EPERM, "You have no permission to list vms.\n");
+					errx(EX_NOPERM, "You have no permission to list vms.\n");
 
 				errno = vm_mmap_getnext(ctx, &gpa, &segid, &segoff, &maplen,
 					&prot, &flags);
 				if (errno)
-					errx(EPERM, "Error to get memory segment information.\n");
+					errx(EX_NOPERM, "Error to get memory segment information.\n");
 
 				humanize_number(numbuf, sizeof(numbuf), maplen, "B",
 					HN_AUTOSCALE, HN_NOSPACE);
@@ -1661,7 +1662,7 @@ list_vm(char *vmname)
 				if (!errno)
 					vcpus = count_vcpus(&cpus);
 				else
-					errx(EPERM, "Error to get the number of vcpus.\n");
+					errx(EX_NOPERM, "Error to get the number of vcpus.\n");
 
 				if (vmname && strcmp(vmname, dir->d_name) == 0) {
 					printf("%s\t\t %s\t\t\t %d\n", dir->d_name,

--- a/usr.sbin/bhyvectl/bhyvectl.c
+++ b/usr.sbin/bhyvectl/bhyvectl.c
@@ -1646,15 +1646,13 @@ list_vm(char *vmname)
 			gpa = 0;
 			if (dir->d_type != DT_DIR) {
 				ctx = vm_open(dir->d_name);
-				if (ctx == NULL) {
+				if (ctx == NULL)
 					errx(EPERM, "You have no permission to list vms.\n");
-				}
 
 				errno = vm_mmap_getnext(ctx, &gpa, &segid, &segoff, &maplen,
 					&prot, &flags);
-				if (errno) {
+				if (errno)
 					errx(EPERM, "Error to get memory segment information.\n");
-				}
 
 				humanize_number(numbuf, sizeof(numbuf), maplen, "B",
 					HN_AUTOSCALE, HN_NOSPACE);
@@ -1662,9 +1660,8 @@ list_vm(char *vmname)
 				errno = vm_active_cpus(ctx, &cpus);
 				if (!errno)
 					vcpus = count_vcpus(&cpus);
-				else {
+				else
 					errx(EPERM, "Error to get the number of vcpus.\n");
-				}
 
 				if (vmname && strcmp(vmname, dir->d_name) == 0) {
 					printf("%s\t\t %s\t\t\t %d\n", dir->d_name,

--- a/usr.sbin/bhyvectl/bhyvectl.c
+++ b/usr.sbin/bhyvectl/bhyvectl.c
@@ -1630,7 +1630,7 @@ list_vm(char *vmname)
 	DIR *path_vmm;
 	struct dirent *dir;
 	struct vmctx *ctx;
-	int error, vcpus = 0;
+	int vcpus = 0;
 	cpuset_t cpus;
 	char numbuf[8];
 	vm_paddr_t gpa;
@@ -1650,17 +1650,17 @@ list_vm(char *vmname)
 					errx(EPERM, "You have no permission to list vms.\n");
 				}
 
-				error = vm_mmap_getnext(ctx, &gpa, &segid, &segoff, &maplen,
+				errno = vm_mmap_getnext(ctx, &gpa, &segid, &segoff, &maplen,
 					&prot, &flags);
-				if (error) {
+				if (errno) {
 					errx(EPERM, "Error to get memory segment information.\n");
 				}
 
 				humanize_number(numbuf, sizeof(numbuf), maplen, "B",
 					HN_AUTOSCALE, HN_NOSPACE);
 
-				error = vm_active_cpus(ctx, &cpus);
-				if (!error)
+				errno = vm_active_cpus(ctx, &cpus);
+				if (!errno)
 					vcpus = count_vcpus(&cpus);
 				else {
 					errx(EPERM, "Error to get the number of vcpus.\n");

--- a/usr.sbin/bhyvectl/bhyvectl.c
+++ b/usr.sbin/bhyvectl/bhyvectl.c
@@ -1663,7 +1663,7 @@ list_vm(char *vmname)
 				if (!error)
 					vcpus = count_vcpus(&cpus);
 				else {
-					errx(EPERM, "Error to get memory segment information.\n");
+					errx(EPERM, "Error to get the number of vcpus.\n");
 				}
 
 				if (vmname && strcmp(vmname, dir->d_name) == 0) {


### PR DESCRIPTION
bhyvectl wasn't designed to control guest vms, instead as a debug tool, these functions create, destroy and list might be moved to a new file.

bhyvectl ex.:
[root@salame] /# bhyvectl --list
NAME		 MEM			 VCPU
fbsd		 1024MB			 3
fbsd2		 512MB			 2
[root@salame] /# bhyvectl --list --vm=fbsd
NAME		 MEM			 VCPU
fbsd		 1024MB			 3