### PR TITLE
- Update poudriere to 3.2.7

### DIFF
--- a/contrib/poudriere/src/bin/poudriere
+++ b/contrib/poudriere/src/bin/poudriere
@@ -29,7 +29,7 @@ LC_ALL=C
 unset SHELL
 SAVED_TERM=$TERM
 unset TERM
-POUDRIERE_VERSION="3.2.6"
+POUDRIERE_VERSION="3.2.7"
 
 usage() {
 	cat << EOF

--- a/contrib/poudriere/src/share/poudriere/html/assets/poudriere.js
+++ b/contrib/poudriere/src/share/poudriere/html/assets/poudriere.js
@@ -71,6 +71,7 @@ function update_data() {
 			'Cache-Control': 'max-age=0',
 		},
 		success: function(data) {
+			load_attempts = 0;
 			process_data(data);
 		},
 		error: function(data) {


### PR DESCRIPTION
Changelog:
    Resetting load attempts counter. The load attempts counter must
    be reset after successful loading of data.json otherwise code will
    react to total number of errors, not sequential one.