### PR TITLE
Boot mute fix

### DIFF
--- a/stand/common/boot.c
+++ b/stand/common/boot.c
@@ -36,6 +36,7 @@ __FBSDID("$FreeBSD$");
 
 #include "bootstrap.h"
 
+static int	autoboot(int timeout, char *prompt);
 static char	*getbootfile(int try);
 static int	loadakernel(int try, int argc, char* argv[]);
 
@@ -157,7 +158,7 @@ autoboot_maybe()
 		autoboot(-1, NULL);		/* try to boot automatically */
 }
 
-int
+static int
 autoboot(int timeout, char *prompt)
 {
 	time_t	when, otime, ntime;

--- a/stand/common/boot.c
+++ b/stand/common/boot.c
@@ -174,6 +174,16 @@ bootenv_flags()
 	return (howto);
 }
 
+void
+bootenv_set(int howto)
+{
+	int i;
+
+	for (i = 0; howto_names[i].ev != NULL; i++)
+		if (howto & howto_names[i].mask)
+			setenv(howto_names[i].ev, "YES", 1);
+}
+
 static int
 autoboot(int timeout, char *prompt)
 {

--- a/stand/common/boot.c
+++ b/stand/common/boot.c
@@ -32,6 +32,8 @@ __FBSDID("$FreeBSD$");
  */
 
 #include <stand.h>
+#include <sys/reboot.h>
+#include <sys/boot.h>
 #include <string.h>
 
 #include "bootstrap.h"
@@ -156,6 +158,20 @@ autoboot_maybe()
 	cp = getenv("autoboot_delay");
 	if ((autoboot_tried == 0) && ((cp == NULL) || strcasecmp(cp, "NO")))
 		autoboot(-1, NULL);		/* try to boot automatically */
+}
+
+int
+bootenv_flags()
+{
+	int i, howto;
+	char *val;
+
+	for (howto = 0, i = 0; howto_names[i].ev != NULL; i++) {
+		val = getenv(howto_names[i].ev);
+		if (val != NULL && strcasecmp(val, "no") != 0)
+			howto |= howto_names[i].mask;
+	}
+	return (howto);
 }
 
 static int

--- a/stand/common/bootstrap.h
+++ b/stand/common/bootstrap.h
@@ -61,7 +61,6 @@ char	*backslash(const char *str);
 int	parse(int *argc, char ***argv, const char *str);
 
 /* boot.c */
-int	autoboot(int timeout, char *prompt);
 void	autoboot_maybe(void);
 int	getrootmount(char *rootdev);
 

--- a/stand/common/bootstrap.h
+++ b/stand/common/bootstrap.h
@@ -63,6 +63,7 @@ int	parse(int *argc, char ***argv, const char *str);
 /* boot.c */
 void	autoboot_maybe(void);
 int	getrootmount(char *rootdev);
+int	bootenv_flags(void);
 
 /* misc.c */
 char	*unargv(int argc, char *argv[]);

--- a/stand/common/bootstrap.h
+++ b/stand/common/bootstrap.h
@@ -64,6 +64,7 @@ int	parse(int *argc, char ***argv, const char *str);
 void	autoboot_maybe(void);
 int	getrootmount(char *rootdev);
 int	bootenv_flags(void);
+void	bootenv_set(int);
 
 /* misc.c */
 char	*unargv(int argc, char *argv[]);

--- a/stand/common/metadata.c
+++ b/stand/common/metadata.c
@@ -31,9 +31,7 @@ __FBSDID("$FreeBSD$");
 
 #include <stand.h>
 #include <sys/param.h>
-#include <sys/reboot.h>
 #include <sys/linker.h>
-#include <sys/boot.h>
 #if defined(LOADER_FDT_SUPPORT)
 #include <fdt_platform.h>
 #endif
@@ -100,7 +98,6 @@ md_getboothowto(char *kargs)
     char	*cp;
     int		howto;
     int		active;
-    int		i;
 
     /* Parse kargs */
     howto = 0;
@@ -153,10 +150,7 @@ md_getboothowto(char *kargs)
 	}
     }
 
-    /* get equivalents from the environment */
-    for (i = 0; howto_names[i].ev != NULL; i++)
-	if (getenv(howto_names[i].ev) != NULL)
-	    howto |= howto_names[i].mask;
+    howto |= bootenv_flags();
 #if defined(__sparc64__)
     if (md_bootserial() != -1)
 	howto |= RB_SERIAL;

--- a/stand/defs.mk
+++ b/stand/defs.mk
@@ -91,7 +91,7 @@ CFLAGS+=	-m32 -mcpu=powerpc
 # build 32-bit and some 64-bit (lib*, efi). Centralize all the 32-bit magic here
 # and activate it when DO32 is explicitly defined to be 1.
 .if ${MACHINE_ARCH} == "amd64" && ${DO32:U0} == 1
-CFLAGS+=	-m32 -mcpu=i386
+CFLAGS+=	-m32
 # LD_FLAGS is passed directly to ${LD}, not via ${CC}:
 LD_FLAGS+=	-m elf_i386_fbsd
 AFLAGS+=	--32

--- a/stand/efi/loader/bootinfo.c
+++ b/stand/efi/loader/bootinfo.c
@@ -32,9 +32,8 @@ __FBSDID("$FreeBSD$");
 #include <stand.h>
 #include <string.h>
 #include <sys/param.h>
-#include <sys/reboot.h>
 #include <sys/linker.h>
-#include <sys/boot.h>
+#include <sys/reboot.h>
 #include <machine/cpufunc.h>
 #include <machine/elf.h>
 #include <machine/metadata.h>
@@ -72,15 +71,9 @@ bi_getboothowto(char *kargs)
 	const char *sw;
 	char *opts;
 	char *console;
-	int howto, i;
+	int howto;
 
-	howto = 0;
-
-	/* Get the boot options from the environment first. */
-	for (i = 0; howto_names[i].ev != NULL; i++) {
-		if (getenv(howto_names[i].ev) != NULL)
-			howto |= howto_names[i].mask;
-	}
+	howto = bootenv_flags();
 
 	console = getenv("console");
 	if (console != NULL) {

--- a/stand/efi/loader/main.c
+++ b/stand/efi/loader/main.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/disk.h>
 #include <sys/param.h>
 #include <sys/reboot.h>
-#include <sys/boot.h>
 #include <stdint.h>
 #include <stand.h>
 #include <string.h>
@@ -549,9 +548,8 @@ main(int argc, CHAR16 *argv[])
 			}
 		}
 	}
-	for (i = 0; howto_names[i].ev != NULL; i++)
-		if (howto & howto_names[i].mask)
-			setenv(howto_names[i].ev, "YES", 1);
+
+	bootenv_set(howto);
 
 	/*
 	 * XXX we need fallback to this stuff after looking at the ConIn, ConOut and ConErr variables

--- a/stand/i386/gptboot/Makefile
+++ b/stand/i386/gptboot/Makefile
@@ -37,7 +37,7 @@ CFLAGS+=-DBOOTPROG=\"gptboot\" \
 	-Wall -Waggregate-return -Wbad-function-cast -Wno-cast-align \
 	-Wmissing-declarations -Wmissing-prototypes -Wnested-externs \
 	-Wpointer-arith -Wshadow -Wstrict-prototypes -Wwrite-strings \
-	-Winline -Wno-pointer-sign
+	-Wno-pointer-sign
 
 CFLAGS.gcc+=	--param max-inline-insns-single=100
 

--- a/stand/i386/gptzfsboot/Makefile
+++ b/stand/i386/gptzfsboot/Makefile
@@ -37,7 +37,7 @@ CFLAGS+=-DBOOTPROG=\"gptzfsboot\" \
 	-Wall -Waggregate-return -Wbad-function-cast \
 	-Wmissing-declarations -Wmissing-prototypes -Wnested-externs \
 	-Wpointer-arith -Wshadow -Wstrict-prototypes -Wwrite-strings \
-	-Winline -Wno-pointer-sign
+	-Wno-pointer-sign
 
 CFLAGS.clang+=	-Wno-tentative-definition-incomplete-type
 

--- a/stand/i386/isoboot/Makefile
+++ b/stand/i386/isoboot/Makefile
@@ -36,6 +36,9 @@ CFLAGS+=-DBOOTPROG=\"isoboot\" \
 	-Winline -Wno-pointer-sign
 
 CFLAGS.gcc+=	--param max-inline-insns-single=100
+.if ${COMPILER_TYPE} == "gcc" && ${COMPILER_VERSION} <= 40201
+CFLAGS.gcc+=	-Wno-uninitialized
+.endif
 CFLAGS.clang+=  -Oz ${CLANG_OPT_SMALL}
 
 LD_FLAGS+=${LD_FLAGS_BIN}

--- a/stand/i386/libi386/bootinfo.c
+++ b/stand/i386/libi386/bootinfo.c
@@ -43,7 +43,6 @@ bi_getboothowto(char *kargs)
     char	*curpos, *next, *string;
     int		howto;
     int		active;
-    int		i;
     int		vidconsole;
 
     /* Parse kargs */
@@ -96,10 +95,7 @@ bi_getboothowto(char *kargs)
 	    cp++;
 	}
     }
-    /* get equivalents from the environment */
-    for (i = 0; howto_names[i].ev != NULL; i++)
-	if (getenv(howto_names[i].ev) != NULL)
-	    howto |= howto_names[i].mask;
+    howto |= bootenv_flags();
 
     /* Enable selected consoles */
     string = next = strdup(getenv("console"));

--- a/stand/i386/libi386/bootinfo.c
+++ b/stand/i386/libi386/bootinfo.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/param.h>
 #include <sys/reboot.h>
 #include <sys/linker.h>
-#include <sys/boot.h>
 #include "bootstrap.h"
 #include "libi386.h"
 #include "btxv86.h"
@@ -130,11 +129,8 @@ bi_getboothowto(char *kargs)
 void
 bi_setboothowto(int howto)
 {
-    int		i;
 
-    for (i = 0; howto_names[i].ev != NULL; i++)
-	if (howto & howto_names[i].mask)
-	    setenv(howto_names[i].ev, "YES", 1);
+    bootenv_set(howto);
 }
 
 /*

--- a/stand/i386/zfsboot/Makefile
+++ b/stand/i386/zfsboot/Makefile
@@ -34,8 +34,7 @@ CFLAGS+=-DBOOTPROG=\"zfsboot\" \
 	-I${BOOTSRC}/i386/boot2 \
 	-Wall -Waggregate-return -Wbad-function-cast -Wno-cast-align \
 	-Wmissing-declarations -Wmissing-prototypes -Wnested-externs \
-	-Wpointer-arith -Wshadow -Wstrict-prototypes -Wwrite-strings \
-	-Winline
+	-Wpointer-arith -Wshadow -Wstrict-prototypes -Wwrite-strings
 
 CFLAGS.gcc+=	--param max-inline-insns-single=100
 .if ${MACHINE} == "amd64"

--- a/stand/userboot/userboot/bootinfo.c
+++ b/stand/userboot/userboot/bootinfo.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/param.h>
 #include <sys/reboot.h>
 #include <sys/linker.h>
-#include <sys/boot.h>
 
 #include "bootstrap.h"
 #include "libuserboot.h"
@@ -131,11 +130,8 @@ bi_getboothowto(char *kargs)
 void
 bi_setboothowto(int howto)
 {
-    int		i;
 
-    for (i = 0; howto_names[i].ev != NULL; i++)
-	if (howto & howto_names[i].mask)
-	    setenv(howto_names[i].ev, "YES", 1);
+    bootenv_set(howto);
 }
 
 /*

--- a/stand/userboot/userboot/bootinfo.c
+++ b/stand/userboot/userboot/bootinfo.c
@@ -43,7 +43,6 @@ bi_getboothowto(char *kargs)
     char	*curpos, *next, *string;
     int		howto;
     int		active;
-    int		i;
     int		vidconsole;
 
     /* Parse kargs */
@@ -96,10 +95,8 @@ bi_getboothowto(char *kargs)
 	    cp++;
 	}
     }
-    /* get equivalents from the environment */
-    for (i = 0; howto_names[i].ev != NULL; i++)
-	if (getenv(howto_names[i].ev) != NULL)
-	    howto |= howto_names[i].mask;
+
+    howto |= bootenv_flags();
 
     /* Enable selected consoles */
     string = next = strdup(getenv("console"));


### PR DESCRIPTION
Bringing in fix of boot_mute and related flags along with some related stuff in tree for clean merge.

Setting no in any combination of case will now disable boot_mute.