### PR TITLE
Update release-trueos.sh

### DIFF
--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -89,7 +89,7 @@ setup_poudriere_conf()
 	echo "BASEFS=$POUDRIERE_BASEFS" >> ${_pdconf}
 	echo "ATOMIC_PACKAGE_REPOSITORY=no" >> ${_pdconf}
 	echo "PKG_REPO_FROM_HOST=yes" >> ${_pdconf}
-	echo "ALLOW_MAKE_JOBS_PACKAGES=\"chromium* iridium* gcc* webkit* llvm* clang* firefox* ruby* cmake* rust*\"" >> ${_pdconf}
+	echo "ALLOW_MAKE_JOBS_PACKAGES=\"chromium* iridium* gcc* webkit* llvm* clang* firefox* ruby* cmake* rust* qt5-web* phantomjs* swift* python2* python3* perl5*\"" >> ${_pdconf}
 	echo "PRIORITY_BOOST=\"pypy* openoffice* iridium* chromium*\"" >> ${_pdconf}
 
 	if [ "$(jq -r '."poudriere-conf" | length' ${TRUEOS_MANIFEST})" != "0" ] ; then


### PR DESCRIPTION
Add a few more packages to the "ALLOW_MAKE_JOBS_PACKAGES":
This will allow these packages to build with multiple cores/threads, and reduce the time that other packages have to sit in the queue waiting for these basic toolkits to complete.
* qt5-web* (qt5-webengine and qt5-webkit - both take a significant amount of time)
* phantomjs* (toolkit which takes quite a while to build - has a few packages which depend on this too)
* swift* (toolkit which takes quite a while to build - has a few packages which depend on this too)
* python[2/3]* (includes all the various versions of the python toolkit (python[2, 27, 3, 34, 35, 36])
* perl5* (toolkit which make ports require - wildcard does not include all ports that *use* perl5, just the toolkit itself)

Closes #96
The only issue from that ticket not resolved by this commit is the "php*" packages. I did not see any way to cleanly separate the php toolkit package away from the packages which *use* php right now (both start with the exact same name/prefix, so a wildcard to catch different versions of php will also include all packages that use php).