### PR TITLE
Add ipmitool and dmidecode to build as essential troubleshooting tools.

### DIFF
--- a/release/manifests/trueos-master.json
+++ b/release/manifests/trueos-master.json
@@ -14,15 +14,23 @@
 	  "www/firefox",
 	  "mail/thunderbird",
 	  "x11/kde5",
+	  "sysutils/ipmitool",
+	  "sysutils/dmidecode",
 	  "sysutils/tmux"
   ],
   "iso-install-packages":[
+	"sysutils/ipmitool",
+	"sysutils/dmidecode",
 	"sysutils/tmux"
   ],
   "dist-packages":[
+	"sysutils/ipmitool",
+	"sysutils/dmidecode",
 	"sysutils/tmux"
   ],
   "auto-install-packages":[
+	"sysutils/ipmitool",
+	"sysutils/dmidecode",
 	"sysutils/tmux"
   ],
   "install-overlay":"",

--- a/release/manifests/trueos-snapshot.json
+++ b/release/manifests/trueos-snapshot.json
@@ -12,6 +12,8 @@
 	  "lang/python",
 	  "lang/python2",
 	  "lang/python3",
+	  "sysutils/ipmitool",
+	  "sysutils/dmidecode",
 	  "editors/vim"
   ],
   "essential-packages":[
@@ -19,13 +21,21 @@
 	  "lang/python",
 	  "lang/python2",
 	  "lang/python3",
+	  "sysutils/ipmitool",
+	  "sysutils/dmidecode",
 	  "editors/vim"
   ],
   "iso-install-packages":[
+	  "sysutils/ipmitool",
+	  "sysutils/dmidecode"
   ],
   "dist-packages":[
+	  "sysutils/ipmitool",
+	  "sysutils/dmidecode"
   ],
   "auto-install-packages":[
+	  "sysutils/ipmitool",
+	  "sysutils/dmidecode"
   ],
   "install-overlay":"",
   "install-script":"",

--- a/release/manifests/trueos-snapshot.json
+++ b/release/manifests/trueos-snapshot.json
@@ -14,6 +14,7 @@
 	  "lang/python3",
 	  "sysutils/ipmitool",
 	  "sysutils/dmidecode",
+	  "www/nginx",
 	  "editors/vim"
   ],
   "essential-packages":[
@@ -23,6 +24,7 @@
 	  "lang/python3",
 	  "sysutils/ipmitool",
 	  "sysutils/dmidecode",
+	  "www/nginx",
 	  "editors/vim"
   ],
   "iso-install-packages":[
@@ -31,11 +33,13 @@
   ],
   "dist-packages":[
 	  "sysutils/ipmitool",
-	  "sysutils/dmidecode"
+	  "sysutils/dmidecode",
+	  "www/nginx"
   ],
   "auto-install-packages":[
 	  "sysutils/ipmitool",
-	  "sysutils/dmidecode"
+	  "sysutils/dmidecode",
+	  "www/nginx"
   ],
   "install-overlay":"",
   "install-script":"",

--- a/release/manifests/trueos-stable.json
+++ b/release/manifests/trueos-stable.json
@@ -14,15 +14,23 @@
 	  "www/firefox",
 	  "mail/thunderbird",
 	  "x11/kde5",
+	  "sysutils/dmidecode",
+	  "sysutils/ipmitool",
 	  "sysutils/tmux"
   ],
   "iso-install-packages":[
+	"sysutils/dmidecode",
+	"sysutils/ipmitool",
 	"sysutils/tmux"
   ],
   "dist-packages":[
+	"sysutils/dmidecode",
+	"sysutils/ipmitool",
 	"sysutils/tmux"
   ],
   "auto-install-packages":[
+	"sysutils/dmidecode",
+	"sysutils/ipmitool",
 	"sysutils/tmux"
   ],
   "install-overlay":"",

--- a/release/trueos-manifest.json
+++ b/release/trueos-manifest.json
@@ -7,22 +7,32 @@
   "package-all":false,
   "packages":[
     "devel/git",
+    "sysutils/ipmitool",
+    "sysutils/dmidecode",
     "sysutils/tmux"
   ],
   "essential-packages":[
     "devel/git",
+    "sysutils/ipmitool",
+    "sysutils/dmidecode",
     "sysutils/tmux"
   ],
   "iso-install-packages":[
     "devel/git",
+    "sysutils/ipmitool",
+    "sysutils/dmidecode",
     "sysutils/tmux"
   ],
   "dist-packages":[
     "devel/git",
+    "sysutils/ipmitool",
+    "sysutils/dmidecode",
     "sysutils/tmux"
   ],
   "auto-install-packages":[
     "devel/git",
+    "sysutils/ipmitool",
+    "sysutils/dmidecode",
     "sysutils/tmux"
   ],
   "install-overlay":"",


### PR DESCRIPTION
Adding to build via manifest instead of putting into base.