### PR TITLE
Request a reference ports build ..

### DIFF
--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -89,8 +89,7 @@ setup_poudriere_conf()
 	echo "BASEFS=$POUDRIERE_BASEFS" >> ${_pdconf}
 	echo "ATOMIC_PACKAGE_REPOSITORY=no" >> ${_pdconf}
 	echo "PKG_REPO_FROM_HOST=yes" >> ${_pdconf}
-	echo "ALLOW_MAKE_JOBS_PACKAGES=\"chromium* iridium* gcc* webkit* llvm* clang* firefox* ruby* cmake* rust* qt5-web* phantomjs* swift* python2* python3* perl5* pypy*\"" >> ${_pdconf}
-	echo "PRIORITY_BOOST=\"pypy* openoffice* iridium* chromium*\"" >> ${_pdconf}
+	echo "ALLOW_MAKE_JOBS=yes" >> ${_pdconf}
 
 	if [ "$(jq -r '."poudriere-conf" | length' ${TRUEOS_MANIFEST})" != "0" ] ; then
 		jq -r '."poudriere-conf" | join("\n")' ${TRUEOS_MANIFEST} >> ${_pdconf}


### PR DESCRIPTION
!! DO NOT PULL THIS !!

While experimenting with the build process and the question how we could archive a package release on daily basis, I need some reference builds from different machines, I'd like to request a full ports tree build with above patch on hydra, to compare that with 2 other builds I have done on other machines.

Last weekends achievement:

HW: 64 Core 128GB Ram
Poudriere config: default
build example: qt5-webengine  15h+ not even completed 
Screenshot: https://prnt.sc/jyy587

HW: 64 Core 128GB Ram
Poudriere config: trueos-default config ALLOW_MAKE_JOBS_PACKAGES=qt5-web*
build example: qt5-webengine  6h 41 min
Screenshot: https://prnt.sc/k1y60q 

HW: 64 Core 128GB Ram
Poudriere config: my config
build example: qt5-webengine  46 min
Screenshot: https://prnt.sc/k130h7

I've done similar tests with clang60, Firefox, Chrome and GccX with similar results.