### PR TITLE
- Improve bhyve exit(3) error code.

### DIFF
--- a/usr.sbin/bhyve/bhyverun.c
+++ b/usr.sbin/bhyve/bhyverun.c
@@ -398,8 +398,7 @@ fbsdrun_deletecpu(struct vmctx *ctx, int vcpu)
 {
 
 	if (!CPU_ISSET(vcpu, &cpumask)) {
-		fprintf(stderr, "Attempting to delete unknown cpu %d\n", vcpu);
-		exit(1);
+		errx(EX_OSERR, "Attempting to delete unknown cpu %d", vcpu);
 	}
 
 	CPU_CLR_ATOMIC(vcpu, &cpumask);
@@ -685,8 +684,7 @@ vmexit_suspend(struct vmctx *ctx, struct vm_exit *vmexit, int *pvcpu)
 	case VM_SUSPEND_TRIPLEFAULT:
 		exit(3);
 	default:
-		fprintf(stderr, "vmexit_suspend: invalid reason %d\n", how);
-		exit(100);
+		errx(EX_OSERR, "vmexit_suspend: invalid reason %d", how);
 	}
 	return (0);	/* NOTREACHED */
 }
@@ -742,9 +740,8 @@ vm_loop(struct vmctx *ctx, int vcpu, uint64_t startrip)
 
 		exitcode = vmexit[vcpu].exitcode;
 		if (exitcode >= VM_EXITCODE_MAX || handler[exitcode] == NULL) {
-			fprintf(stderr, "vm_loop: unexpected exitcode 0x%x\n",
+			errx(EX_SOFTWARE, "vm_loop: unexpected exitcode 0x%x",
 			    exitcode);
-			exit(1);
 		}
 
 		rc = (*handler[exitcode])(ctx, &vmexit[vcpu], &vcpu);
@@ -755,7 +752,7 @@ vm_loop(struct vmctx *ctx, int vcpu, uint64_t startrip)
 		case VMEXIT_ABORT:
 			abort();
 		default:
-			exit(1);
+			exit(EX_UNAVAILABLE);
 		}
 	}
 	fprintf(stderr, "vm_run error %d, errno %d\n", error, errno);
@@ -786,8 +783,7 @@ fbsdrun_set_capabilities(struct vmctx *ctx, int cpu)
 	if (fbsdrun_vmexit_on_hlt()) {
 		err = vm_get_capability(ctx, cpu, VM_CAP_HALT_EXIT, &tmp);
 		if (err < 0) {
-			fprintf(stderr, "VM exit on HLT not supported\n");
-			exit(1);
+			errx(EX_SOFTWARE, "VM exit on HLT not support");
 		}
 		vm_set_capability(ctx, cpu, VM_CAP_HALT_EXIT, 1);
 		if (cpu == BSP)
@@ -800,9 +796,7 @@ fbsdrun_set_capabilities(struct vmctx *ctx, int cpu)
 		 */
 		err = vm_get_capability(ctx, cpu, VM_CAP_PAUSE_EXIT, &tmp);
 		if (err < 0) {
-			fprintf(stderr,
-			    "SMP mux requested, no pause support\n");
-			exit(1);
+			errx(EX_NOPERM, "SMP mux requested, no pause support");
 		}
 		vm_set_capability(ctx, cpu, VM_CAP_PAUSE_EXIT, 1);
 		if (cpu == BSP)
@@ -815,8 +809,7 @@ fbsdrun_set_capabilities(struct vmctx *ctx, int cpu)
 		err = vm_set_x2apic_state(ctx, cpu, X2APIC_DISABLED);
 
 	if (err) {
-		fprintf(stderr, "Unable to set x2apic state (%d)\n", err);
-		exit(1);
+		errx(EX_SOFTWARE, "Unable to set x2apic state (%d)", err);
 	}
 
 	vm_set_capability(ctx, cpu, VM_CAP_ENABLE_INVPCID, 1);
@@ -851,8 +844,7 @@ do_open(const char *vmname)
 				 */
 			}
 		} else {
-			perror("vm_create");
-			exit(1);
+			err(errno, "vm_create");
 		}
 	} else {
 		if (!romboot) {
@@ -860,15 +852,13 @@ do_open(const char *vmname)
 			 * If the virtual machine was just created then a
 			 * bootrom must be configured to boot it.
 			 */
-			fprintf(stderr, "virtual machine cannot be booted\n");
-			exit(1);
+			errx(EX_USAGE, "virtual machine cannot be booted");
 		}
 	}
 
 	ctx = vm_open(vmname);
 	if (ctx == NULL) {
-		perror("vm_open");
-		exit(1);
+		err(errno, "vm_open");
 	}
 
 #ifndef WITHOUT_CAPSICUM
@@ -889,8 +879,7 @@ do_open(const char *vmname)
 	if (reinit) {
 		error = vm_reinit(ctx);
 		if (error) {
-			perror("vm_reinit");
-			exit(1);
+			err(errno, "vm_reinit");
 		}
 	}
 	error = vm_set_topology(ctx, sockets, cores, threads, maxcpus);
@@ -972,7 +961,7 @@ main(int argc, char *argv[])
 			break;
 		case 's':
 			if (pci_parse_slot(optarg) != 0)
-				exit(1);
+				errx(EX_USAGE, "invalid pci slot");
 			else
 				break;
 		case 'S':
@@ -1036,9 +1025,8 @@ main(int argc, char *argv[])
 
 	max_vcpus = num_vcpus_allowed(ctx);
 	if (guest_ncpus > max_vcpus) {
-		fprintf(stderr, "%d vCPUs requested but only %d available\n",
-			guest_ncpus, max_vcpus);
-		exit(1);
+		errx(EX_SOFTWARE, "%d vCPUs requested but only %d available",
+		    guest_ncpus, max_vcpus);
 	}
 
 	fbsdrun_set_capabilities(ctx, BSP);
@@ -1046,14 +1034,12 @@ main(int argc, char *argv[])
 	vm_set_memflags(ctx, memflags);
 	err = vm_setup_memory(ctx, memsize, VM_MMAP_ALL);
 	if (err) {
-		fprintf(stderr, "Unable to setup memory (%d)\n", errno);
-		exit(1);
+		errx(EX_NOPERM, "Unable to setup memory (%d)", errno);
 	}
 
 	error = init_msr();
 	if (error) {
-		fprintf(stderr, "init_msr error %d", error);
-		exit(1);
+		errx(EX_SOFTWARE, "init_msr error %d", error);
 	}
 
 	init_mem();
@@ -1069,7 +1055,8 @@ main(int argc, char *argv[])
 	 * Exit if a device emulation finds an error in its initilization
 	 */
 	if (init_pci(ctx) != 0)
-		exit(1);
+		errx(EX_UNAVAILABLE,
+		    "device emulation initialization error");
 
 	if (dbg_port != 0)
 		init_dbgport(dbg_port);
@@ -1082,9 +1069,8 @@ main(int argc, char *argv[])
 
 	if (lpc_bootrom()) {
 		if (vm_set_capability(ctx, BSP, VM_CAP_UNRESTRICTED_GUEST, 1)) {
-			fprintf(stderr, "ROM boot failed: unrestricted guest "
-			    "capability not available\n");
-			exit(1);
+			errx(EX_UNAVAILABLE, "ROM boot failed: unrestricted "
+			    "guest capability not available");
 		}
 		error = vcpu_reset(ctx, BSP);
 		assert(error == 0);
@@ -1099,7 +1085,7 @@ main(int argc, char *argv[])
 	if (mptgen) {
 		error = mptable_build(ctx, guest_ncpus);
 		if (error)
-			exit(1);
+			errx(EX_SOFTWARE, "build the guest tables");
 	}
 
 	error = smbios_build(ctx);
@@ -1138,5 +1124,5 @@ main(int argc, char *argv[])
 	 */
 	mevent_dispatch();
 
-	exit(1);
+	errx(EX_SOFTWARE, "internal software error");
 }

--- a/usr.sbin/bhyve/dbgport.c
+++ b/usr.sbin/bhyve/dbgport.c
@@ -139,8 +139,7 @@ init_dbgport(int sport)
 	conn_fd = -1;
 
 	if ((listen_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		perror("socket");
-		exit(1);
+		err(errno, "cannot create a socket");
 	}
 
 	sin.sin_len = sizeof(sin);
@@ -151,18 +150,15 @@ init_dbgport(int sport)
 	reuse = 1;
 	if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse,
 	    sizeof(reuse)) < 0) {
-		perror("setsockopt");
-		exit(1);
+		err(errno, "cannot set socket options");
 	}
 
 	if (bind(listen_fd, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
-		perror("bind");
-		exit(1);
+		err(errno, "cannot bind to the socket");
 	}
 
 	if (listen(listen_fd, 1) < 0) {
-		perror("listen");
-		exit(1);
+		err(errno, "cannot listen socket");
 	}
 
 #ifndef WITHOUT_CAPSICUM

--- a/usr.sbin/bhyve/fwctl.c
+++ b/usr.sbin/bhyve/fwctl.c
@@ -41,9 +41,11 @@ __FBSDID("$FreeBSD$");
 #include <sys/uio.h>
 
 #include <assert.h>
+#include <err.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sysexits.h>
 
 #include "bhyverun.h"
 #include "inout.h"
@@ -374,8 +376,7 @@ fwctl_request(uint32_t value)
 	case 0:
 		/* Verify size */
 		if (value < 12) {
-			printf("msg size error");
-			exit(1);
+			errx(EX_SOFTWARE, "msg size error");
 		}
 		rinfo.req_size = value;
 		rinfo.req_count = 1;

--- a/usr.sbin/bhyve/mevent_test.c
+++ b/usr.sbin/bhyve/mevent_test.c
@@ -42,8 +42,10 @@
 #include <netinet/in.h>
 #include <machine/cpufunc.h>
 
+#include <err.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sysexits.h>
 #include <pthread.h>
 #include <unistd.h>
 
@@ -142,8 +144,7 @@ echoer(void *param)
 
 	mev = mevent_add(fd, EVF_READ, echoer_callback, &sync);
 	if (mev == NULL) {
-		printf("Could not allocate echoer event\n");
-		exit(1);
+		errx(EX_OSERR, "Could not allocate echoer event");
 	}
 
 	while (!pthread_cond_wait(&sync.e_cond, &sync.e_mt)) {
@@ -200,8 +201,7 @@ acceptor(void *param)
 	static int first;
 
 	if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		perror("socket");
-		exit(1);
+		err(errno, "socket");
 	}
 
 	sin.sin_len = sizeof(sin);
@@ -210,13 +210,11 @@ acceptor(void *param)
 	sin.sin_port = htons(TEST_PORT);
 
 	if (bind(s, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
-		perror("bind");
-		exit(1);
+		err(errno, "bind");
 	}
 
 	if (listen(s, 1) < 0) {
-		perror("listen");
-		exit(1);
+		err(errno, "listen");
 	}
 
 	(void) mevent_add(s, EVF_READ, acceptor_callback, NULL);

--- a/usr.sbin/bhyve/pci_e82545.c
+++ b/usr.sbin/bhyve/pci_e82545.c
@@ -2223,8 +2223,7 @@ e82545_open_tap(struct e82545_softc *sc, char *opts)
 
 	sc->esc_tapfd = open(tbuf, O_RDWR);
 	if (sc->esc_tapfd == -1) {
-		DPRINTF("unable to open tap device %s\n", opts);
-		exit(1);
+		errx(EX_OSFILE, "unable to open tap device %s", opts);
 	}
 
 	/*


### PR DESCRIPTION
The bhyve(8) exit status indicates how the VM was terminated:
	0       rebooted
	1       powered off
	2       halted
	3       triple fault

The problem is when we have wrappers around bhyve that parses the exit error code and gets an exit(1) for an error but inteprets it as "powered off".
So to mitigate this issue and makes it less error prone for third part applications, I have replaced exit(3) with value 1 to err(3) with a proper exit error from sysexits(3).

TEST PLAN
As an example without patch:

1) "Could not open backing file":
root@mp03:/ # bhyve -A -H -P -c 3 -m 8098M -s 0:0,hostbridge -s 31,lpc -l com1,/dev/nmdm1A -l bootrom,/usr/local/share/uefi-firmware/BHYVE_UEFI.fd -s 29,fbuf,tcp=10.20.21.2:6032,w=800,h=600 -s 30,xhci,tablet -s 4,virtio-blk,/dev/la/la -s 5,virtio-net,tap10,mac=00:a0:98:2c:d5:9f FreeBSD
bhyve: Could not open backing file: /dev/la/la: No such file or directory
Could not open backing file: No such file or directory
root@mp03:/ # echo $?
1

2) "Invalid PCI slot number":
root@mp03:/ # bhyve -A -H -P -c 3 -m 8098M -s 0:0,hostbridge -s 31,lpc -l com1,/dev/nmdm1A -l bootrom,/usr/local/share/uefi-firmware/BHYVE_UEFI.fd -s 29,fbuf,tcp=10.20.21.2:6032,w=800,h=600 -s 30,xhci,tablet -s 4,virtio-blk,/dev/la/la -s 50000000,virtio-net,tap10,mac=00:a0:98:2c:d5:9f FreeBSD
Invalid PCI slot info field "50000000,virtio-net,tap10,mac=00:a0:98:2c:d5:9f"
root@mp03:/ # echo $?
1

Example with this patch:

1) "Could not open backing file":
root@mp03:/ # bhyve -A -H -P -c 3 -m 8098M -s 0:0,hostbridge -s 31,lpc -l com1,/dev/nmdm1A -l bootrom,/usr/local/share/uefi-firmware/BHYVE_UEFI.fd -s 29,fbuf,tcp=10.20.21.2:6032,w=800,h=600 -s 30,xhci,tablet -s 4,virtio-blk,/dev/la/la -s 5,virtio-net,tap10,mac=00:a0:98:2c:d5:9f FreeBSD
bhyve: la Could not open backing file: /dev/la/la: No such file or directory
Could not open backing file: No such file or directory
bhyve: device emulation error in its initialization
root@mp03:/ # echo $?
69

2) "Invalid PCI slot number":
root@mp03:/ # bhyve -A -H -P -c 3 -m 8098M -s 0:0,hostbridge -s 31,lpc -l com1,/dev/nmdm1A -l bootrom,/usr/local/share/uefi-firmware/BHYVE_UEFI.fd -s 29,fbuf,tcp=10.20.21.2:6032,w=800,h=600 -s 30,xhci,tablet -s 4,virtio-blk,/dev/la/la -s 500000000,virtio-net,tap10,mac=00:a0:98:2c:d5:9f FreeBSD
Invalid PCI slot info field "500000000,virtio-net,tap10,mac=00:a0:98:2c:d5:9f"
bhyve: invalid pci slot
root@mp03:/ # echo $?
64

From review: https://reviews.freebsd.org/D16161