### PR TITLE
Add support for specifying post install commands in the JSON

### DIFF
--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -301,6 +301,13 @@ EOF
 			 >${OBJDIR}/disc1/root/auto-dist-install
 	fi
 
+	# Check if we have any post install commands to run
+	if [ "$(jq -r '."post-install-commands" | length' ${TRUEOS_MANIFEST})" != "0" ] ; then
+		echo "Saving post-install commands"
+		jq -r '."post-install-commands"' ${TRUEOS_MANIFEST} \
+			 >${OBJDIR}/disc1/root/post-install-commands.json
+	fi
+
 	# Create the install repo DB config
 	mkdir -p ${OBJDIR}/disc1/etc/pkg
 	cat >${OBJDIR}/disc1/etc/pkg/TrueOS.conf <<EOF

--- a/release/trueos-manifest.json
+++ b/release/trueos-manifest.json
@@ -40,6 +40,24 @@
   "install-overlay":"",
   "install-script":"",
   "auto-install-script":"",
+  "post-install-commands": [
+	  {
+		"chroot":true,
+		"command":"touch /root/inside-chroot"
+	  },
+	  {
+		"chroot":false,
+		"command":"true /root/outside-chroot"
+	  },
+	  {
+		"chroot":false,
+		"command":"rm /root/outside-chroot"
+	  },
+	  {
+		"chroot":true,
+		"command":"rm /root/inside-chroot"
+	  }
+  ],
   "pkg-repo": {
 	  "url":"https://pkg.trueos.org/pkg/unstable/ports/${ABI}/latest",
 	  "pubKey": [


### PR DESCRIPTION
manifest.

Commands will be specified with:

"post-install-commands": [
   {
         "chroot":true,
         "command":"touch /root/inside-chroot"
   }
]

Where chroot indicates if the command is to be run inside or outside
the installed system's chroot.

This fixes #117