### PR TITLE
Add initial support for setting an ISO name in our JSON manifest,

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -279,6 +279,7 @@ dvd: packagesystem
 
 release.iso: disc1.iso
 disc1.iso: disc1
+	env GITHASH=$$(git log -1 --pretty=format:%h 2>/dev/null) \
 	sh ${.CURDIR}/${TARGET}/mkisoimages.sh -b ${VOLUME_LABEL}_CD ${.TARGET} disc1 ${XTRADIR}
 
 dvd1.iso: dvd pkg-stage

--- a/release/Makefile
+++ b/release/Makefile
@@ -46,6 +46,7 @@ DOCDIR?=	/usr/doc
 PKG_CMD?=	pkg-static
 TRUEOS_MANIFEST?=	${WORLDDIR}/release/trueos-manifest.json
 RELNOTES_LANG?= en_US.ISO8859-1
+GITHASH=	$$(cd ${WORLDIR}/.. ; git log -1 --pretty=format:%h 2>/dev/null)
 
 .if !defined(TARGET) || empty(TARGET)
 TARGET=		${MACHINE}
@@ -279,7 +280,7 @@ dvd: packagesystem
 
 release.iso: disc1.iso
 disc1.iso: disc1
-	env GITHASH=$$(git log -1 --pretty=format:%h 2>/dev/null) \
+	env GITHASH=${GITHASH} \
 	TRUEOS_MANIFEST=${TRUEOS_MANIFEST} \
 	sh ${.CURDIR}/${TARGET}/mkisoimages.sh -b ${VOLUME_LABEL}_CD ${.TARGET} disc1 ${XTRADIR}
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -279,7 +279,7 @@ dvd: packagesystem
 
 release.iso: disc1.iso
 disc1.iso: disc1
-	env GITHASH=$(git log -1 --pretty=format:%h 2>/dev/null) \
+	env GITHASH=$$(git log -1 --pretty=format:%h 2>/dev/null) \
 	TRUEOS_MANIFEST=${TRUEOS_MANIFEST} \
 	sh ${.CURDIR}/${TARGET}/mkisoimages.sh -b ${VOLUME_LABEL}_CD ${.TARGET} disc1 ${XTRADIR}
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -46,7 +46,6 @@ DOCDIR?=	/usr/doc
 PKG_CMD?=	pkg-static
 TRUEOS_MANIFEST?=	${WORLDDIR}/release/trueos-manifest.json
 RELNOTES_LANG?= en_US.ISO8859-1
-GITHASH=	$(git log -1 --pretty=format:%h -C ${WORLDDIR})
 
 .if !defined(TARGET) || empty(TARGET)
 TARGET=		${MACHINE}
@@ -103,7 +102,7 @@ RELEASE_TARGETS= ftp
 IMAGES=
 .if exists(${.CURDIR}/${TARGET}/mkisoimages.sh)
 RELEASE_TARGETS+= cdrom
-IMAGES+=	disc1.iso bootonly.iso
+IMAGES+=	disc1.iso
 . if defined(WITH_DVD) && !empty(WITH_DVD)
 RELEASE_TARGETS+= dvdrom
 IMAGES+=	dvd1.iso
@@ -280,7 +279,7 @@ dvd: packagesystem
 
 release.iso: disc1.iso
 disc1.iso: disc1
-	env GITHASH=${GITHASH} \
+	env SRCDIR=${.CURDIR}/.. \
 	TRUEOS_MANIFEST=${TRUEOS_MANIFEST} \
 	sh ${.CURDIR}/${TARGET}/mkisoimages.sh -b ${VOLUME_LABEL}_CD ${.TARGET} disc1 ${XTRADIR}
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -46,7 +46,7 @@ DOCDIR?=	/usr/doc
 PKG_CMD?=	pkg-static
 TRUEOS_MANIFEST?=	${WORLDDIR}/release/trueos-manifest.json
 RELNOTES_LANG?= en_US.ISO8859-1
-GITHASH=	$$(cd ${WORLDIR}/.. ; git log -1 --pretty=format:%h 2>/dev/null)
+GITHASH=	$(git log -1 --pretty=format:%h -C ${WORLDDIR})
 
 .if !defined(TARGET) || empty(TARGET)
 TARGET=		${MACHINE}

--- a/release/Makefile
+++ b/release/Makefile
@@ -279,7 +279,8 @@ dvd: packagesystem
 
 release.iso: disc1.iso
 disc1.iso: disc1
-	env GITHASH=$$(git log -1 --pretty=format:%h 2>/dev/null) \
+	env GITHASH=$(git log -1 --pretty=format:%h 2>/dev/null) \
+	TRUEOS_MANIFEST=${TRUEOS_MANIFEST} \
 	sh ${.CURDIR}/${TARGET}/mkisoimages.sh -b ${VOLUME_LABEL}_CD ${.TARGET} disc1 ${XTRADIR}
 
 dvd1.iso: dvd pkg-stage

--- a/release/amd64/mkisoimages.sh
+++ b/release/amd64/mkisoimages.sh
@@ -112,9 +112,9 @@ if [ "$bootable" != "" ]; then
 fi
 
 FILE_RENAME="$(jq -r '."iso-file-name"' $TRUEOS_MANIFEST)"
-if [ -n "$FILE_RENAME" -a "$FILE_RENAME" != "null" -a "$NAME" = "disc1" ] ; then
+if [ -n "$FILE_RENAME" -a "$FILE_RENAME" != "null" -a "$NAME" = "disc1.iso" ] ; then
   DATE="$(date +%Y%m%d)"
   FILE_RENAME=$(echo $FILE_RENAME | sed "s|%%GITHASH%%|$GITHASH|g" | sed "s|%%DATE%%|$DATE|g")
   echo "Renaming ${NAME}.iso -> ${FILE_RENAME}.iso"
-  mv ${NAME}.iso ${FILE_RENAME}.iso
+  mv ${NAME} ${FILE_RENAME}.iso
 fi

--- a/release/amd64/mkisoimages.sh
+++ b/release/amd64/mkisoimages.sh
@@ -111,6 +111,7 @@ if [ "$bootable" != "" ]; then
 	rm -f hybrid.img
 fi
 
+GITHASH=$(git -C ${SRCDIR} log -1 --pretty=format:%h)
 FILE_RENAME="$(jq -r '."iso-file-name"' $TRUEOS_MANIFEST)"
 if [ -n "$FILE_RENAME" -a "$FILE_RENAME" != "null" -a "$NAME" = "disc1.iso" ] ; then
   DATE="$(date +%Y%m%d)"

--- a/release/amd64/mkisoimages.sh
+++ b/release/amd64/mkisoimages.sh
@@ -72,6 +72,8 @@ if [ -n "$TRUEOS_MANIFEST" ] ; then
 	else
 		echo "Using OVERLAY_DIR: $OVERLAY_DIR"
 	fi
+else
+	echo "WARNING: TRUEOS_MANIFEST not set"
 fi
 
 LABEL=`echo "$1" | tr '[:lower:]' '[:upper:]'`; shift

--- a/release/amd64/mkisoimages.sh
+++ b/release/amd64/mkisoimages.sh
@@ -110,8 +110,9 @@ if [ "$bootable" != "" ]; then
 fi
 
 FILE_RENAME="$(jq -r '."iso-file-name"' $TRUEOS_MANIFEST)"
-if [ -n "$FILE_RENAME" -a "$FILE_RENAME" = "null" ] ; then
+if [ -n "$FILE_RENAME" -a "$FILE_RENAME" != "null" -a "$NAME" = "disc1" ] ; then
   DATE="$(date +%Y%m%d)"
   FILE_RENAME=$(echo $FILE_RENAME | sed "s|%%GITHASH%%|$GITHASH|g" | sed "s|%%DATE%%|$DATE|g")
+  echo "Renaming ${NAME}.iso -> ${FILE_RENAME}.iso"
   mv ${NAME}.iso ${FILE_RENAME}.iso
 fi

--- a/release/amd64/mkisoimages.sh
+++ b/release/amd64/mkisoimages.sh
@@ -52,7 +52,7 @@ if [ "$1" = "-b" ]; then
 	rmdir efi
 	mdconfig -d -u $device
 	bootable="$bootable -o bootimage=i386;efiboot.img -o no-emul-boot -o platformid=efi"
-	
+
 	shift
 else
 	BASEBITSDIR="$3"
@@ -107,4 +107,11 @@ if [ "$bootable" != "" ]; then
 	# Drop the PMBR, GPT, and boot code into the System Area of the ISO.
 	dd if=hybrid.img of="$NAME" bs=32k count=1 conv=notrunc
 	rm -f hybrid.img
+fi
+
+FILE_RENAME="$(jq -r '."iso-file-name"' $TRUEOS_MANIFEST)"
+if [ -n "$FILE_RENAME" -a "$FILE_RENAME" = "null" ] ; then
+  DATE="$(date +%Y%m%d)"
+  FILE_RENAME=$(echo $FILE_RENAME | sed "s|%%GITHASH%%|$GITHASH|g" | sed "s|%%DATE%%|$DATE|g")
+  mv ${NAME}.iso ${FILE_RENAME}.iso
 fi

--- a/release/trueos-manifest.json
+++ b/release/trueos-manifest.json
@@ -18,6 +18,7 @@
     "sysutils/dmidecode",
     "sysutils/tmux"
   ],
+  "iso-file-name":"TrueOS-x64-%%GITHASH%%-%%DATE%%.iso",
   "iso-install-packages":[
     "archivers/cabextract",
     "devel/git",

--- a/release/trueos-manifest.json
+++ b/release/trueos-manifest.json
@@ -18,7 +18,7 @@
     "sysutils/dmidecode",
     "sysutils/tmux"
   ],
-  "iso-file-name":"TrueOS-x64-%%GITHASH%%-%%DATE%%.iso",
+  "iso-file-name":"TrueOS-x64-%%GITHASH%%-%%DATE%%",
   "iso-install-packages":[
     "archivers/cabextract",
     "devel/git",


### PR DESCRIPTION
this includes using the %%GITHASH%% and %%DATE%% expansion variables
in the filename.

fixes #119 