### PR TITLE
Unbreak VLANs after r337943.

### DIFF
--- a/sys/net/if_ethersubr.c
+++ b/sys/net/if_ethersubr.c
@@ -461,7 +461,8 @@ ether_output_frame(struct ifnet *ifp, struct mbuf *m)
 	uint8_t pcp;
 
 	pcp = ifp->if_pcp;
-	if (pcp != IFNET_PCP_NONE && !ether_set_pcp(&m, ifp, pcp))
+	if (pcp != IFNET_PCP_NONE && ifp->if_type != IFT_L2VLAN &&
+	    !ether_set_pcp(&m, ifp, pcp))
 		return (0);
 
 	if (PFIL_HOOKED(&V_link_pfil_hook)) {


### PR DESCRIPTION
ether_set_pcp should not be called from ether_output_frame for VLAN
interfaces -- the vid + pcp will be inserted during vlan_transmit in
that case. r337943 sets the VLAN's ifnet's if_pcp to a proper PCP value
and this led to double encapsulation (once with vid 0 and second time
with vid+pcp).

PR: 230794
Reviewed by:	kib@
Approved by:	re@ (gjb@)
Sponsored by:	Chelsio Communications
Differential Revision:	https://reviews.freebsd.org/D16887