### PR TITLE
Improve how we set pkg repos. Instead of hacking the files into the

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -57,6 +57,17 @@ _MKSHOWCONFIG=	t
 SRCDIR?=	${.CURDIR}
 LOCALBASE?=	/usr/local
 
+
+# Check if TRUEOS_MANIFEST is set, if not use the default
+.if !defined(TRUEOS_MANIFEST)
+TRUEOS_MANIFEST=	${SRCDIR}/release/trueos-manifest.json
+.endif
+
+# Confirm the file TRUEOS_MANIFEST exists
+.if !exists(${TRUEOS_MANIFEST})
+.error "Missing file TRUEOS_MANIFEST: ${TRUEOS_MANIFEST}"
+.endif
+
 # Cross toolchain changes must be in effect before bsd.compiler.mk
 # so that gets the right CC, and pass CROSS_TOOLCHAIN to submakes.
 .if defined(CROSS_TOOLCHAIN)
@@ -1787,6 +1798,8 @@ create-world-package-${pkgname}: .PHONY
 		sed -i '' -e "s/%VCS_REVISION%/${VCS_REVISION}/" ${WSTAGEDIR}/${pkgname}.ucl ; \
 		${WSTAGEDIR}/usr/sbin/etcupdate build -s ${SRCDIR} ${WSTAGEDIR}/var/db/etcupdate-current.tbz ; \
 		echo "/var/db/etcupdate-current.tbz" >> ${WSTAGEDIR}/${pkgname}.plist ; \
+		cp ${TRUEOS_MANIFEST} ${WSTAGEDIR}/var/db/trueos-manifest.json ; \
+		echo "/var/db/trueos-manifest.json" >> ${WSTAGEDIR}/${pkgname}.plist ; \
 	fi
 	${PKG_CMD} -o ABI_FILE=${WSTAGEDIR}/bin/sh -o ALLOW_BASE_SHLIBS=yes \
 		create -M ${WSTAGEDIR}/${pkgname}.ucl \

--- a/release/packages/runtime.ucl
+++ b/release/packages/runtime.ucl
@@ -18,6 +18,7 @@ desc = <<EOD
 EOD
 scripts: {
 	post-install = <<EOD
+	TM=/var/db/trueos-manifest.json
 	if [ -z "${PKG_ROOTDIR}" ] ; then
 		PKG_ROOTDIR=/
 	fi
@@ -30,6 +31,44 @@ scripts: {
 		# Update existing /etc directory
 		echo "** Performing automated etcupdate of /etc **"
 		etcupdate -D ${PKG_ROOTDIR} -a -t ${PKG_ROOTDIR}/var/db/etcupdate-current.tbz
+	fi
+
+	# Do the first-time setup of package repo
+	if [ ! -e "${PKG_ROOTDIR}/etc/pkg/TrueOS.conf" ] ; then
+
+		# Do Setup for ports repo
+		TM_PUBKEY="none"
+		if [ "$(jq -r '."pkg-repo"."pubKey" | length' ${TM})" != "0" ]; then
+			echo "Saving pkg ports repository public key"
+			jq -r '."pkg-repo"."pubKey" | join("\n")' ${TM} \
+			> ${PKG_ROOTDIR}/usr/share/keys/pkg/trueos.pub
+			TM_PUBKEY="/usr/share/keys/pkg/trueos.pub"
+		fi
+		if [ "$(jq -r '."pkg-repo"."url" | length' ${TM})" != "0" ]; then
+			TM_PKGURL="$(jq -r '."pkg-repo"."url"' ${TM})"
+			cat ${PKG_ROOTDIR}/etc/pkg/TrueOS.conf.pubkey.dist \
+			| sed "s|%%REPONAME%%|TrueOS-ports|g" \
+			| sed "s|%%PUBKEY%%|${TM_PUBKEY}|g" \
+			| sed "s|%%URL%%|${TM_PKGURL}|g" \
+			>${PKG_ROOTDIR}/etc/pkg/TrueOS.conf
+		fi
+
+		# Do Setup for base repo
+		TM_PUBKEY="none"
+		if [ "$(jq -r '."base-pkg-repo"."pubKey" | length' ${TM})" != "0" ]; then
+			echo "Saving pkg base repository public key"
+			jq -r '."base-pkg-repo"."pubKey" | join("\n")' ${TM} \
+			>${PKG_ROOTDIR}/usr/share/keys/pkg/trueos-base.pub
+			TM_PUBKEY="/usr/share/keys/pkg/trueos-base.pub"
+		fi
+		if [ "$(jq -r '."base-pkg-repo"."url" | length' ${TM})" != "0" ]; then
+			TM_PKGURL="$(jq -r '."base-pkg-repo"."url"' ${TM})"
+			cat ${PKG_ROOTDIR}/etc/pkg/TrueOS.conf.pubkey.dist \
+			| sed "s|%%REPONAME%%|TrueOS-base|g" \
+			| sed "s|%%PUBKEY%%|${TM_PUBKEY}|g" \
+			| sed "s|%%URL%%|${TM_PKGURL}|g" \
+			>>${PKG_ROOTDIR}/etc/pkg/TrueOS.conf
+		fi
 	fi
 
 	cap_mkdb %CAP_MKDB_ENDIAN% ${PKG_ROOTDIR}/etc/login.conf

--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -415,42 +415,6 @@ apply_iso_config()
 
 }
 
-save_pkg_config()
-{
-	if [ "$(jq -r '."pkg-repo"."url" | length' ${TRUEOS_MANIFEST})" = "0" ]; then
-		return 0
-	fi
-
-	_jspkgurl="$(jq -r '."pkg-repo"."url"' ${TRUEOS_MANIFEST})"
-	echo "Saving pkg repository URL"
-	echo "$_jspkgurl" > ${OBJDIR}/disc1/dist/trueos-pkg-url
-
-	# Check if a pubkey is specified
-	if [ "$(jq -r '."pkg-repo"."pubKey" | length' ${TRUEOS_MANIFEST})" != "0" ]; then
-		echo "Saving pkg repository public key"
-		jq -r '."pkg-repo"."pubKey" | join("\n")' ${TRUEOS_MANIFEST} \
-			> ${OBJDIR}/disc1/dist/trueos-pkg-url.pubkey
-	fi
-}
-
-save_base_pkg_config()
-{
-	if [ "$(jq -r '."base-pkg-repo"."url" | length' ${TRUEOS_MANIFEST})" = "0" ]; then
-		return 0
-	fi
-
-	_jspkgurl="$(jq -r '."base-pkg-repo"."url"' ${TRUEOS_MANIFEST})"
-	echo "Saving base pkg repository URL"
-	echo "$_jspkgurl" > ${OBJDIR}/disc1/dist/trueos-base-pkg-url
-
-	# Check if a pubkey is specified
-	if [ "$(jq -r '."base-pkg-repo"."pubKey" | length' ${TRUEOS_MANIFEST})" != "0" ]; then
-		echo "Saving pkg repository public key"
-		jq -r '."base-pkg-repo"."pubKey" | join("\n")' ${TRUEOS_MANIFEST} \
-			> ${OBJDIR}/disc1/dist/trueos-base-pkg-url.pubkey
-	fi
-}
-
 env_check
 
 case $1 in
@@ -458,8 +422,6 @@ case $1 in
 	poudriere) run_poudriere ;;
 	iso) cp_iso_pkgs
 	     apply_iso_config
-	     save_pkg_config
-	     save_base_pkg_config
 	     ;;
 	*) echo "Unknown option selected" ;;
 esac

--- a/usr.sbin/pc-sysinstall/backend/functions-cleanup.sh
+++ b/usr.sbin/pc-sysinstall/backend/functions-cleanup.sh
@@ -382,45 +382,6 @@ set_root_pw()
 
 run_final_cleanup()
 {
-  # Check if we have any package repo to enable
-  if [ -e "/dist/trueos-pkg-url" ] ; then
-    _pkgUrl="$(cat /dist/trueos-pkg-url)"
-    if [ -e "/dist/trueos-pkg-url.pubkey" ] ; then
-	cp /dist/trueos-pkg-url.pubkey ${FSMNT}/usr/share/keys/pkg/trueos.pub
-	cat ${FSMNT}/etc/pkg/TrueOS.conf.pubkey.dist \
-		| sed "s|%%REPONAME%%|TrueOS-ports|g" \
-		| sed "s|%%PUBKEY%%|/usr/share/keys/pkg/trueos.pub|g" \
-		| sed "s|%%URL%%|${_pkgUrl}|g" \
-		>${FSMNT}/etc/pkg/TrueOS.conf
-    else
-	cat ${FSMNT}/etc/pkg/TrueOS.conf.pubkey.dist \
-		| grep -v 'pubkey:' \
-		| sed "s|%%REPONAME%%|TrueOS-base|g" \
-		| sed 's|pubkey|none|g' \
-		| sed "s|%%URL%%|${_pkgUrl}|g" \
-		>${FSMNT}/etc/pkg/TrueOS.conf
-    fi
-  fi
-
-  # Do the same for base-pkg urls
-  if [ -e "/dist/trueos-base-pkg-url" ] ; then
-    _pkgUrl="$(cat /dist/trueos-base-pkg-url)"
-    if [ -e "/dist/trueos-base-pkg-url.pubkey" ] ; then
-	cp /dist/trueos-base-pkg-url.pubkey ${FSMNT}/usr/share/keys/pkg/trueos-base.pub
-	cat ${FSMNT}/etc/pkg/TrueOS.conf.pubkey.dist \
-		| sed "s|%%REPONAME%%|TrueOS-base|g" \
-		| sed "s|%%PUBKEY%%|/usr/share/keys/pkg/trueos-base.pub|g" \
-		| sed "s|%%URL%%|${_pkgUrl}|g" \
-		>>${FSMNT}/etc/pkg/TrueOS.conf
-    else
-	cat ${FSMNT}/etc/pkg/TrueOS.conf.pubkey.dist \
-		| grep -v 'pubkey:' \
-		| sed "s|%%REPONAME%%|TrueOS-base|g" \
-		| sed 's|pubkey|none|g' \
-		| sed "s|%%URL%%|${_pkgUrl}|g" \
-		>>${FSMNT}/etc/pkg/TrueOS.conf
-    fi
-  fi
 
   # Check if we need to run any gmirror setup
   ls ${MIRRORCFGDIR}/* >/dev/null 2>/dev/null


### PR DESCRIPTION
ISO and pc-sysinstall, lets save the TRUEOS_MANIFEST directly into
the FreeBSD-runtime package and use this as the basis of generating
/etc/pkg/TrueOS.conf on install / upgrade of FreeBSD-runtime.

This means installing a new chroot or jail with 'pkg' will result
in a properly setup pkg repo, as well as on fresh-install.

This fixes #136