### PR TITLE
Update rc for ISO media

### DIFF
--- a/release/rc
+++ b/release/rc
@@ -26,7 +26,8 @@ fi
 # /usr/local/etc to be R/W for services like networking
 # mouse and other to start on live/install media
 /sbin/mount -t tmpfs tmpfs /tmp
-/sbin/mount -t tmpfs tmpfs /var/tmp
+/sbin/mount -t tmpfs tmpfs /var
+/bin/mkdir -p /var/tmp
 /bin/mkdir -p /tmp/etc
 /bin/mkdir -p /tmp/localetc
 /bin/cp -r /etc/* /tmp/etc/


### PR DESCRIPTION
Make sure that all of /var is read-write, not just /var/tmp.
In particular, /var/run and /var/log are needed to be writable to startup some base services (moused and devd in particular)