### PR TITLE
Dynamicdiskless

### DIFF
--- a/sbin/init/Makefile
+++ b/sbin/init/Makefile
@@ -4,6 +4,7 @@
 CONFGROUPS=	CONFETC CONFETCEXEC CONFETCDEFAULTS CONFTTYS
 CONFETCDIR=	/etc
 CONFETC=	network.subr openrc openrc.shutdown rc rc.initdiskless rc.subr rc.shutdown
+CONFETC+=	rc.dynamicdiskless
 CONFETCMODE=	644
 CONFETCEXEC=	netstart pccard_ether rc.resume rc.suspend
 CONFETCEXECDIR=	/etc

--- a/sbin/init/rc
+++ b/sbin/init/rc
@@ -28,6 +28,11 @@
 # $FreeBSD$
 #
 
+# Do we want to do a dynamic diskless setup?
+if [ -f /etc/dynamicdiskless ]; then
+	sh /etc/rc.dynamicdiskless
+fi
+
 # Are we using OpenRC instead of RC?
 if [ "$(/bin/kenv rc_system 2>/dev/null)" = "openrc" ]; then
    sh /etc/openrc

--- a/sbin/init/rc.dynamicdiskless
+++ b/sbin/init/rc.dynamicdiskless
@@ -1,0 +1,96 @@
+#!/bin/sh
+#
+# Copyright (c) 2018  Kris Moore
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# $FreeBSD$
+
+# This script is similar in concept to rc.initdiskless (Read that file!)
+#
+# It specifically probes the directories /conf/base/SUBDIR looking
+# for directories the user wishes to copy into tmpfs backed file-systems
+# and re-mounted on top of the base.
+#
+# Some key differences:
+#
+# /conf/base/SUBDIR directories do not have # to be pre-populated. Just
+# having a blank directory there indicates the # desire to convert that
+# directory to a tmpfs backed FS. Contents from the original location
+# will be copied over on boot, and then moved back into the tmpfs location
+# of the existing directory.
+#
+# /conf/base/DIR__DIR__SUBDIR is allowed. An example would be wanting to
+# use /conf/base/usr__local__etc which would make /usr/local/etc
+# a tmpfs backed FS.
+
+copy_subdir()
+{
+	CDIR=$(basename $1)
+	TDIR=$(basename $1 | sed 's|__|/|g')
+	if [ ! -d "$TDIR" ] ; then
+		echo "ERROR: /conf/base/$TDIR was specified but /$TDIR does not exist"
+		return 1
+	fi
+
+	mount -t tmpfs tmpfs /conf/base/$CDIR
+	if [ $? -ne 0 ] ; then
+		echo "ERROR: Failed mounting tmpfs on /conf/base/$CDIR"
+		return 1
+	fi
+
+	cp -a /${TDIR}/ /conf/base/${CDIR}/
+	if [ $? -ne 0 ] ; then
+		echo "ERROR: Failed copying $TDIR -> /conf/base/$CDIR"
+		return 1
+	fi
+
+	mount -t tmpfs tmpfs $TDIR
+	if [ $? -ne 0 ] ; then
+		echo "ERROR: Failed mounting tmpfs on /$TDIR"
+		return 1
+	fi
+
+	cp -a /conf/base/${CDIR}/ /${TDIR}/
+	if [ $? -ne 0 ] ; then
+		echo "ERROR: Failed copying /conf/base/$CDIR -> /$TDIR"
+		return 1
+	fi
+}
+
+# Do we have anything to do?
+if [ ! -d "/conf/base/" ] ; then
+	return 0
+fi
+
+# Make sure tmpfs is loaded
+kldload tmpfs 2>/dev/null
+
+# Lets grab a list of dirs to work on
+for SUBDIR in $(find /conf/base -type d -depth 1 | tr -s '\n' ' ')
+do
+	copy_subdir ${SUBDIR}
+done
+
+# DONE
+exit 0


### PR DESCRIPTION
This PR fixes an issue preventing FreeNAS usage. We can dynamically copy files from the base FS into tmpfs /conf/base/SUBDIR and then copy back into tmpfs backed /SUBDIR locations. This fixes issues with wanting to not have writes hit the disk on particular directories. 