### PR TITLE
added security/ca_root_nss

### DIFF
--- a/release/manifests/trueos-snapshot.json
+++ b/release/manifests/trueos-snapshot.json
@@ -17,7 +17,8 @@
         "sysutils/ipmitool",
         "sysutils/dmidecode",
         "sysutils/tmux",
-        "www/nginx"
+        "www/nginx",
+        "security/ca_root_nss"
       ]
     },
     "auto-install-script": "",


### PR DESCRIPTION
when we build base with openssl we need security/ca_root_nss default installed to overcome  httpS Authentication errors