### PR TITLE
Update release-trueos.sh

### DIFF
--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -246,6 +246,9 @@ setup_poudriere_jail()
 		if [ $? -ne 0 ] ; then
 			exit_err "Failed creating poudriere ports - NULLFS"
 		fi
+		# Also fix the internal variable pointing to the location of the ports tree on disk
+		# This is used for checking essential packages later
+		POUDRIERE_PORTDIR=${PORTS_URL}
 	fi
 
 	rm ${POUDRIERED_DIR}/${POUDRIERE_BASE}-make.conf


### PR DESCRIPTION
Fix the internal variable pointing to the location of the on-disk ports tree when a "local" ports tree is used.
This is needed for the essential packages check later to be run properly.