### PR TITLE
Update mkisoimages.sh

### DIFF
--- a/release/amd64/mkisoimages.sh
+++ b/release/amd64/mkisoimages.sh
@@ -145,7 +145,10 @@ if [ "$bootable" != "" ]; then
 	rm -f hybrid.img
 fi
 
-GITHASH=$(git -C ${SRCDIR} log -1 --pretty=format:%h)
+if [ -d "${SRCDIR}/.git" ] ; then
+  #Source tree is a git checkout: Get the git hash/tag
+  GITHASH=$(git -C ${SRCDIR} log -1 --pretty=format:%h)
+fi
 FILE_RENAME="$(jq -r '."iso."."file-name"' $TRUEOS_MANIFEST)"
 if [ -n "$FILE_RENAME" -a "$FILE_RENAME" != "null" -a "$NAME" = "disc1.iso" ] ; then
   DATE="$(date +%Y%m%d)"


### PR DESCRIPTION
Only check for the git hash if the source tree is a clone of a git repo.
This should fix the issue with the function crashing on non-git checkouts of the source tree and the ISO not getting renamed appropriately.