### PR TITLE
- Fix AHCI timeouts on Mac Mini 7,1

### DIFF
--- a/sys/dev/ahci/ahci_pci.c
+++ b/sys/dev/ahci/ahci_pci.c
@@ -350,6 +350,7 @@ static const struct {
 	{0x01861039, 0x00, "SiS 968",		0},
 	{0xa01c177d, 0x00, "ThunderX",		AHCI_Q_ABAR0|AHCI_Q_1MSI},
 	{0x00311c36, 0x00, "Annapurna",		AHCI_Q_FORCE_PI|AHCI_Q_RESTORE_CAP|AHCI_Q_NOMSIX},
+	{0x1600144d, 0x00, "SAMSUNG",		AHCI_Q_NOMSI},
 	{0x00000000, 0x00, NULL,		0}
 };
 


### PR DESCRIPTION
With MSI on we getting those errors,

ahcich0: Timeout on slot 13 port 0
ahcich0: is 00000008 cs 00000000 ss 00000000 rs 00003ff0 tfd 40 serr 00000000 cmd 0000cd17
(ada0:ahcich0:0:0:0): READ_FPDMA_QUEUED. ACB: 60 08 f8 eb b2 40 00 00 00 00 00 00
(ada0:ahcich0:0:0:0): CAM status: Command timeout
(ada0:ahcich0:0:0:0): Retrying command, 3 more tries remain
ahcich0: Timeout on slot 18 port 0

this patch fix the issue.