### PR TITLE
Adding part-label option to get mbr primary partition info to pc-sysinstall

### DIFF
--- a/usr.sbin/pc-sysinstall/backend-query/Makefile
+++ b/usr.sbin/pc-sysinstall/backend-query/Makefile
@@ -7,7 +7,7 @@ FILES=	detect-country.sh detect-laptop.sh detect-nics.sh detect-emulation.sh \
 	list-tzones.sh query-langs.sh send-logs.sh set-mirror.sh setup-ssh-keys.sh \
 	list-zpools.sh \
 	sys-mem.sh test-live.sh test-netup.sh update-part-list.sh xkeyboard-layouts.sh \
-	xkeyboard-models.sh xkeyboard-variants.sh
+	xkeyboard-models.sh xkeyboard-variants.sh part-label.sh
 FILESMODE=	${BINMODE}
 FILESDIR=${SHAREDIR}/pc-sysinstall/backend-query
 

--- a/usr.sbin/pc-sysinstall/backend-query/part-label.sh
+++ b/usr.sbin/pc-sysinstall/backend-query/part-label.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+#-
+# Copyright (c) 2018 iXsystems, Inc.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# $FreeBSD: $
+
+# Query mbr partitions label and display them
+##############################
+
+. ${PROGDIR}/backend/functions.sh
+. ${PROGDIR}/backend/functions-disk.sh
+
+
+if [ -z "${1}" ]
+then
+  echo "Error: No partition specified!"
+  exit 1
+fi
+
+if [ ! -e "/dev/${1}" ]
+then
+  echo "Error: Partition /dev/${1} does not exist!"
+  exit 1
+fi
+
+
+gpart show ${1} >/dev/null 2>/dev/null
+if [ "$?" != "0" ] ; then
+  # No partitions on this disk, display entire disk size and exit
+  echo "Not a primary partition"
+  exit
+fi
+
+
+SLICE_PART="${1}"
+TMPDIR=${TMPDIR:-"/tmp"}
+
+TYPE=`gpart show ${1} | awk '/^=>/ { printf("%s",$5); }'`
+echo "${1}-format: $TYPE"
+
+# Set some search flags
+PART="0"
+EXTENDED="0"
+START="0"
+SIZEB="0"
+
+# Get a listing of partitions on this disk
+get_partitions_lables "${SLICE_PART}"
+LABELS="${VAL}"
+for curpart in $LABELS
+do
+
+  # First get the sysid / label for this partition
+  get_partition_label "${SLICE_PART}" "${curpart}"
+  echo "${curpart}-sysid: ${VAL}"
+  echo "${curpart}-label: ${VAL}"
+
+  # Now get the startblock, blocksize and MB size of this partition
+  get_label_startblock "${SLICE_PART}" "${curpart}"
+  START="${VAL}"
+  echo "${curpart}-blockstart: ${START}"
+
+  get_label_blocksize "${SLICE_PART}" "${curpart}"
+  SIZEB="${VAL}"
+  echo "${curpart}-blocksize: ${SIZEB}"
+
+  SIZEMB=$(convert_blocks_to_megabyte ${SIZEB})
+  echo "${curpart}-sizemb: ${SIZEMB}"
+
+done
+
+
+# Now calculate any free space
+FREEB=`gpart show ${SLICE_PART} | grep '\- free\ -' | awk '{print $2}' | sort -g | tail -1`
+FREEMB="`expr ${FREEB} / 2048`"
+echo "${1}-freemb: $FREEMB"
+echo "${1}-freeblocks: $FREEB"

--- a/usr.sbin/pc-sysinstall/backend-query/part-label.sh
+++ b/usr.sbin/pc-sysinstall/backend-query/part-label.sh
@@ -47,8 +47,8 @@ fi
 
 gpart show ${1} >/dev/null 2>/dev/null
 if [ "$?" != "0" ] ; then
-  # No partitions on this disk, display entire disk size and exit
-  echo "Not a primary partition"
+  # Partitons is not a primary partition
+  echo "${1} is not a primary partition"
   exit
 fi
 
@@ -65,7 +65,7 @@ EXTENDED="0"
 START="0"
 SIZEB="0"
 
-# Get a listing of partitions on this disk
+# Get a listing of partitions from the primary partition
 get_partitions_lables "${SLICE_PART}"
 LABELS="${VAL}"
 for curpart in $LABELS
@@ -96,3 +96,4 @@ FREEB=`gpart show ${SLICE_PART} | grep '\- free\ -' | awk '{print $2}' | sort -g
 FREEMB="`expr ${FREEB} / 2048`"
 echo "${1}-freemb: $FREEMB"
 echo "${1}-freeblocks: $FREEB"
+

--- a/usr.sbin/pc-sysinstall/doc/help-index
+++ b/usr.sbin/pc-sysinstall/doc/help-index
@@ -5,28 +5,28 @@ Help Commands
     help
 	Display this index file
 
-    help <command> 
+    help <command>
    	Display the help data for the specified command
 
 System Query Commands
     install-image <image> <device>
         Installs an image file to a device file
 
-    disk-list 
+    disk-list
         Provides a listing of the disk drives detected on this system
 
     disk-part <disk>
         Queries the specified disk and returns information about its partitions
-    
+
     disk-info <disk>
-        Returns information about the disks size, cyls, heads, and sectors 
-    
+        Returns information about the disks size, cyls, heads, and sectors
+
     detect-laptop
         Tests to see if this system is a laptop or desktop
 
     detect-emulation
         Tests to see if this system is actually running in an emulator such as VirtualBox
-    
+
     detect-nics
         Returns a listing of the detected network cards on this system
 
@@ -44,14 +44,17 @@ System Query Commands
 
     list-rsync-backups <user> <host> <port>
         Returns a listing of available rsync-backups on the target server in the life-preserver/ dir
-    
+
     list-tzones
         Returns a listing of available timezones
 
-    query-langs 
+    part-label <partition>
+        Queries the specified partition and returns information about its label
+
+    query-langs
         Return a list of languages that the installer supports
 
-    get-packages 
+    get-packages
         Retrieves the list of packages from an FTP mirror
 
     sys-mem
@@ -62,13 +65,13 @@ System Query Commands
 
     test-netup
         Test if an internet connection is available
-    
+
     update-part-list
         Return a list of TrueOS & FreeBSD installs on this system for updates
 
     xkeyboard-layouts
         Return a list of keyboard layouts that xorg supports
-  
+
     xkeyboard-models
         Return a list of keyboard models that xorg supports
 
@@ -79,11 +82,11 @@ Partition Management Commands
 
    create-part <disk> <size>
 	Create a new MBR primary slice on the target <disk> using <size> MB
-	
+
    delete-part <partition>
 	Deletes the disk partition specified. If this is the last partition,
 	the disk partition layout will also be scrubbed, leaving a clean disk
-	ready for MBR or GPT file system layouts. 
+	ready for MBR or GPT file system layouts.
 
 
 Installation Commands
@@ -96,5 +99,5 @@ Installation Commands
         Normally only used by automated install scripts
 
     setup-ssh-keys <user> <host> <port>
-	Setup SSH without a password for the target host and user and port	
+	Setup SSH without a password for the target host and user and port
         Use to prompt the user to log into a server before doing a rsync + ssh restore

--- a/usr.sbin/pc-sysinstall/pc-sysinstall/pc-sysinstall.8
+++ b/usr.sbin/pc-sysinstall/pc-sysinstall/pc-sysinstall.8
@@ -79,6 +79,8 @@ Returns a listing of available rsync-backups on the target server in the
 life-preserver/ directory.
 .It list-tzones
 Returns a listing of available timezones.
+.It part-label Ar partition
+Queries the specified partition and returns information about its labels.
 .It query-langs
 Returns a list of languages that the installer supports.
 .It sys-mem

--- a/usr.sbin/pc-sysinstall/pc-sysinstall/pc-sysinstall.sh
+++ b/usr.sbin/pc-sysinstall/pc-sysinstall/pc-sysinstall.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 #####################################################################
 #       Author: Kris Moore
-#      License: BSD 
-#  Description: pc-sysinstall provides a backend for performing 
+#      License: BSD
+#  Description: pc-sysinstall provides a backend for performing
 #  system installations, as well as calls which a front-end can use
 #  to retrive information about the system
 #####################################################################
@@ -56,11 +56,11 @@ export CONFDIR
 #####################################################################
 
 # Set our QUERYDIR
-QUERYDIR="${PROGDIR}/backend-query" 
+QUERYDIR="${PROGDIR}/backend-query"
 export QUERYDIR
 
 # Set our BACKEND
-BACKEND="${PROGDIR}/backend" 
+BACKEND="${PROGDIR}/backend"
 export BACKEND
 
 PARTMANAGERDIR="${PROGDIR}/backend-partmanager"
@@ -79,7 +79,7 @@ fi
 IGNORE_OSVERSION="yes"
 export IGNORE_OSVERSION=yes
 
-# Now source our functions.sh 
+# Now source our functions.sh
 if [ -e "${PROGDIR}/backend/functions.sh" ]
 then
   . ${PROGDIR}/backend/functions.sh
@@ -138,7 +138,7 @@ case $1 in
   # The user is wanting to see what nics are available on the system
   detect-nics) ${QUERYDIR}/detect-nics.sh
   ;;
-  
+
   # The user is wanting to check if we are in emulation
   detect-emulation) ${QUERYDIR}/detect-emulation.sh
   ;;
@@ -150,7 +150,7 @@ case $1 in
   # The user is wanting to query which disks are available
   disk-list) ${QUERYDIR}/disk-list.sh $*
   ;;
-  
+
   # The user is wanting to query a disk's partitions
   disk-part) ${QUERYDIR}/disk-part.sh ${2}
   ;;
@@ -183,6 +183,10 @@ case $1 in
   list-zpools) ${QUERYDIR}/list-zpools.sh
   ;;
 
+  # The user is wanting to query a partitions
+  part-label) ${QUERYDIR}/part-label.sh ${2}
+  ;;
+
   # Requested a list of languages this install will support
   query-langs) ${QUERYDIR}/query-langs.sh
   ;;
@@ -198,7 +202,7 @@ case $1 in
   # Function which allows setting up of SSH keys
   setup-ssh-keys) ${QUERYDIR}/setup-ssh-keys.sh "${2}" "${3}" "${4}"
   ;;
-  
+
   # Function which lists the real memory of the system in MB
   sys-mem) ${QUERYDIR}/sys-mem.sh
   ;;
@@ -206,7 +210,7 @@ case $1 in
   # Run script which determines if we are booted from install media, or on disk
   test-live) ${QUERYDIR}/test-live.sh
   ;;
-  
+
   # The user is wanting to test if the network is up and working
   test-netup) ${QUERYDIR}/test-netup.sh
   ;;
@@ -218,16 +222,16 @@ case $1 in
   # Requested a list of keyboard layouts that xorg supports
   xkeyboard-layouts) ${QUERYDIR}/xkeyboard-layouts.sh
   ;;
-  
+
   # Requested a list of keyboard models that xorg supports
   xkeyboard-models) ${QUERYDIR}/xkeyboard-models.sh
   ;;
-  
+
   # Requested a list of keyboard variants that xorg supports
   xkeyboard-variants) ${QUERYDIR}/xkeyboard-variants.sh
   ;;
-           
-  *) echo "Unknown Command: ${1}" 
+
+  *) echo "Unknown Command: ${1}"
      exit 1 ;;
 esac
 


### PR DESCRIPTION
* added get_partitions_lables, get_partition_label, get_label_startblock, and get_label_blocksize functions to functions-disk
* added part-label.sh backend-query
* added part-label in documention
* updated Makefile

example of output

```
pc-sysinstall part-label ada1s1
ada1s1-format: BSD
ada1s1a-sysid: freebsd-ufs
ada1s1a-label: freebsd-ufs
ada1s1a-blockstart: 0
ada1s1a-blocksize: 975515648
ada1s1a-sizemb: 476326
ada1s1b-sysid: freebsd-swap
ada1s1b-label: freebsd-swap
ada1s1b-blockstart: 975515648
ada1s1b-blocksize: 1048576
ada1s1b-sizemb: 512
ada1s1-freemb: 101
ada1s1-freeblocks: 208880
```

```
pc-sysinstall part-label ada2s1
ada2s1 is not a primary partition
```