### PR TITLE
Update release-trueos.sh

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -102,7 +102,9 @@ The "iso" target within the manifest controls all the options specific to creati
 * "dist-packages" (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO
    * "default" (JSON array of strings) : Default list (required)
    * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "dist-packages-are-essential" (boolian) : (default: true) Include the list of dist-packages in the essential package checks for verifying if a build was successful.
+* "optional-dist-packages" (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO. These ones are considered "optional" and may or may not be included depending on whether the package built successfully.
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
 * "iso-packages" (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
    * "default" (JSON array of strings) : Default list (required)
    * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.

--- a/release/README.md
+++ b/release/README.md
@@ -102,6 +102,7 @@ The "iso" target within the manifest controls all the options specific to creati
 * "dist-packages" (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO
    * "default" (JSON array of strings) : Default list (required)
    * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "dist-packages-are-essential" (boolian) : (default: true) Include the list of dist-packages in the essential package checks for verifying if a build was successful.
 * "iso-packages" (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
    * "default" (JSON array of strings) : Default list (required)
    * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.

--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -470,12 +470,8 @@ check_essential_pkgs()
 		ESSENTIAL="$ESSENTIAL $(jq -r '."ports"."build"."'$c'" | join(" ")' ${TRUEOS_MANIFEST})"
 	done
 
-	#See if we need to include the dist-packages as essential or not (default: YES)
-	local _include_dist_as_essential=$(jq -r '."iso"."dist-packages-are-essential"' $TRUEOS_MANIFEST)
-	local _checklist="iso-packages auto-install-packages"
-	if [ "false" != "${include_dist_as_essential}" ] ; then
-	  _checklist="${_checklist} dist-packages"
-	fi
+	#Check any other iso lists for essential packages
+	local _checklist="iso-packages auto-install-packages dist-packages"
 	# Check for any conditional packages to build in iso
 	for ptype in ${_checklist}
 	do
@@ -620,7 +616,8 @@ cp_iso_pkgs()
 	rm ${OBJDIR}/disc1/root/auto-dist-install 2>/dev/null
 
 	# Check if we have dist-packages to include on the ISO
-	for ptype in dist-packages auto-install-packages
+	local _missingpkgs=""
+	for ptype in dist-packages auto-install-packages optional-dist-packages
 	do
 		for c in $(jq -r '."iso"."'${ptype}'" | keys[]' ${TRUEOS_MANIFEST} 2>/dev/null | tr -s '\n' ' ')
 		do
@@ -633,7 +630,12 @@ cp_iso_pkgs()
 					-R ${OBJDIR}/repo-config \
 					fetch -y -d -o ${TARGET_DIR}/${ABI_DIR}/${PKG_VERSION} $i
 					if [ $? -ne 0 ] ; then
-						exit_err "Failed copying dist-package $i to ISO..."
+						if [ "${ptype}" = "optional-dist-packages" ] ; then
+							echo "WARNING: Optional dist package missing: $i"
+							_missingpkgs="${_missingpkgs} $i"
+						else
+							exit_err "Failed copying dist-package $i to ISO..."
+						fi
 					fi
 			done
 			if [ "$ptype" = "auto-install-packages" ] ; then
@@ -643,7 +645,9 @@ cp_iso_pkgs()
 			fi
 		done
 	done
-
+	if [ -n "${_missingpkgs}" ] ; then
+	  echo "WARNING: Optional Packages not available for ISO: ${_missingpkgs}"
+	fi
 	# Create the repo DB
 	echo "Creating installer pkg repo"
 	pkg-static repo ${TARGET_DIR}/${ABI_DIR}/${PKG_VERSION}


### PR DESCRIPTION
Update the essential packages checks a bit:
1. If any essential packages are missing, print out the full list of package names which are missing at the end of the routine.
2. Add a new JSON manifest option: "iso" -> "optional-dist-packages". This is treated the same as the "dist-packages" lists, but are not used when doing the essential package checks (optional packages will not fail the build if they are not available).