### PR TITLE
Update runtime.ucl

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -283,3 +283,27 @@ PKG_REPO_FROM_HOST=yes
 ALLOW_MAKE_JOBS_PACKAGES="chomium* iridium* gcc* webkit* llvm* clang* firefox* ruby* cmake* rust*"
 PRIORITY_BOOST="pypy* openoffice* iridium* chromium*"
 ```
+
+### pkg-repo
+As part of the build process, the packages can also be automatically assembled into a full package repository which may be used for providing access to the newly-build packages on other systems.
+
+#### pkg-repo Options
+* "pkg-repo-name" (string) : Short-name for the package repository (default: "TrueOS")
+* "pkg-repo" (JSON Object) : Settings for the unified base+ports package repo
+   * "url" (string) : Public URL where the repository can be found. (Distro creators will need to setup access for this URL and copy the pkg repo files as needed to make them available at the given location).
+   * "pubKey" (JSON Array of strings) : SSL public key to use when verifying integrity of downloaded packages (one line of test per item in the array). This is basically just the plain-text of the SSL public key file converted into an array of strings. 
+      * **WARNING** Make sure that this public key is the complement to the private key that you are using to sign the packages!!
+   
+#### pkg-repo Example
+
+```
+"pkg-repo-name" : "TrueOS",
+"pkg-repo" : {
+  "url" : "http://pkg.trueos.org/pkg/release/${ABI}/latest",
+  "pubKey : [
+    "-----BEGIN PUBLIC KEY-----",
+    "sdigosbhdgiub+asdgilpubLIUYASVBfiGULiughlBHJljib"
+    "-----END PUBLIC KEY-----"
+  ]
+}
+```

--- a/release/packages/runtime.ucl
+++ b/release/packages/runtime.ucl
@@ -22,25 +22,28 @@ scripts: {
 		PKG_ROOTDIR=/
 	fi
 	TM=${PKG_ROOTDIR}/var/db/trueos-manifest.json
-
+	REPONAME="TrueOS"
+	if [ "$(jq -r '."pkg-repo-name" | length' ${TM})" != "0" ]; then
+		REPONAME=`jq -r '."pkg-repo-name"' ${TM}`
+	fi
 	# Do the first-time setup of package repo
-	if [ ! -e "${PKG_ROOTDIR}/etc/pkg/TrueOS.conf" ] ; then
+	if [ ! -e "${PKG_ROOTDIR}/etc/pkg/${REPONAME}.conf" ] ; then
 
 		# Do Setup for ports repo
 		TM_PUBKEY="none"
 		if [ "$(jq -r '."pkg-repo"."pubKey" | length' ${TM})" != "0" ]; then
 			echo "Saving pkg ports repository public key"
 			jq -r '."pkg-repo"."pubKey" | join("\n")' ${TM} \
-			> ${PKG_ROOTDIR}/usr/share/keys/pkg/trueos.pub
-			TM_PUBKEY="/usr/share/keys/pkg/trueos.pub"
+			> ${PKG_ROOTDIR}/usr/share/keys/pkg/${REPONAME}.pub
+			TM_PUBKEY="/usr/share/keys/pkg/${REPONAME}.pub"
 		fi
 		if [ "$(jq -r '."pkg-repo"."url" | length' ${TM})" != "0" ]; then
 			TM_PKGURL="$(jq -r '."pkg-repo"."url"' ${TM})"
 			cat ${PKG_ROOTDIR}/etc/pkg/TrueOS.conf.pubkey.dist \
-			| sed "s|%%REPONAME%%|TrueOS-ports|g" \
+			| sed "s|%%REPONAME%%|${REPONAME}|g" \
 			| sed "s|%%PUBKEY%%|${TM_PUBKEY}|g" \
 			| sed "s|%%URL%%|${TM_PKGURL}|g" \
-			>${PKG_ROOTDIR}/etc/pkg/TrueOS.conf
+			>${PKG_ROOTDIR}/etc/pkg/${REPONAME}.conf
 		fi
 
 		# Do Setup for base repo
@@ -48,16 +51,16 @@ scripts: {
 		if [ "$(jq -r '."base-pkg-repo"."pubKey" | length' ${TM})" != "0" ]; then
 			echo "Saving pkg base repository public key"
 			jq -r '."base-pkg-repo"."pubKey" | join("\n")' ${TM} \
-			>${PKG_ROOTDIR}/usr/share/keys/pkg/trueos-base.pub
-			TM_PUBKEY="/usr/share/keys/pkg/trueos-base.pub"
+			>${PKG_ROOTDIR}/usr/share/keys/pkg/${REPONAME}-base.pub
+			TM_PUBKEY="/usr/share/keys/pkg/${REPONAME}-base.pub"
 		fi
 		if [ "$(jq -r '."base-pkg-repo"."url" | length' ${TM})" != "0" ]; then
 			TM_PKGURL="$(jq -r '."base-pkg-repo"."url"' ${TM})"
 			cat ${PKG_ROOTDIR}/etc/pkg/TrueOS.conf.pubkey.dist \
-			| sed "s|%%REPONAME%%|TrueOS-base|g" \
+			| sed "s|%%REPONAME%%|${REPONAME}-base|g" \
 			| sed "s|%%PUBKEY%%|${TM_PUBKEY}|g" \
 			| sed "s|%%URL%%|${TM_PKGURL}|g" \
-			>>${PKG_ROOTDIR}/etc/pkg/TrueOS.conf
+			>>${PKG_ROOTDIR}/etc/pkg/${REPONAME}.conf
 		fi
 	fi
 


### PR DESCRIPTION
New JSON manifest option:
"pkg-repo-name" (string)
This will be used as the name when setting up the package repo (Default value: "TrueOS")
Example: 
* /etc/pkg/TrueOS.conf -> /etc/pkg/[pkg-repo-name].conf
* "TrueOS-[ports/base]" for repo name in the config becomes "[pkg-repo-name][-base]"
* /usr/share/keys/pkg/trueos-[ports/base].pub -> /usr/share/keys/pkg/[pkg-repo-name][-base].pub