### PR TITLE
Update release-trueos.sh

### DIFF
--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -593,7 +593,8 @@ cp_iso_pkgs()
 
 	# Check if we have dist-packages to include on the ISO
 	local _missingpkgs=""
-	for ptype in dist-packages auto-install-packages optional-dist-packages
+	# Note: Make sure that "prune-dist-packages" is always last in this list!!
+	for ptype in dist-packages auto-install-packages optional-dist-packages prune-dist-packages
 	do
 		for c in $(jq -r '."iso"."'${ptype}'" | keys[]' ${TRUEOS_MANIFEST} 2>/dev/null | tr -s '\n' ' ')
 		do
@@ -601,10 +602,19 @@ cp_iso_pkgs()
 			if [ -z "$CHECK" -a "$c" != "default" ] ; then continue; fi
 			for i in $(jq -r '."iso"."'${ptype}'"."'$c'" | join(" ")' ${TRUEOS_MANIFEST})
 			do
-				echo "Fetching image dist-files for: $i"
-				pkg-static -o ABI_FILE=${OBJDIR}/disc1/bin/sh \
-					-R ${OBJDIR}/repo-config \
-					fetch -y -d -o ${TARGET_DIR}/${ABI_DIR}/${PKG_VERSION} $i
+				if [ -n "${i}" ] ; then continue; fi
+				if [ "${ptype}" = "prune-dist-packages" ] ; then
+					for prune in `ls ${TARGET_DIR}/${ABI_DIR}/${PKG_VERSION} | grep -i -e "${i}*.txz"`
+					do
+						echo "Pruning image dist-file: $prune"
+						rm "${TARGET_DIR}/${ABI_DIR}/${PKG_VERSION}/${prune}"
+					done
+					
+				else
+					echo "Fetching image dist-files for: $i"
+					pkg-static -o ABI_FILE=${OBJDIR}/disc1/bin/sh \
+						-R ${OBJDIR}/repo-config \
+						fetch -y -d -o ${TARGET_DIR}/${ABI_DIR}/${PKG_VERSION} $i
 					if [ $? -ne 0 ] ; then
 						if [ "${ptype}" = "optional-dist-packages" ] ; then
 							echo "WARNING: Optional dist package missing: $i"
@@ -613,6 +623,7 @@ cp_iso_pkgs()
 							exit_err "Failed copying dist-package $i to ISO..."
 						fi
 					fi
+				fi
 			done
 			if [ "$ptype" = "auto-install-packages" ] ; then
 				echo "Saving package list to auto-install from: $c"
@@ -667,8 +678,8 @@ EOF
 	chroot ${OBJDIR}/disc1 cap_mkdb /etc/login.conf
 	touch ${OBJDIR}/disc1/etc/fstab
 
-	# Check for explict pkgs to install, minus development and debug
-	for e in $(get_explicit_pkg_deps "development debug")
+	# Check for explict pkgs to install, minus development, debug, and profile
+	for e in $(get_explicit_pkg_deps "development debug profile")
 	do
 		pkg-static -o ABI_FILE=/bin/sh \
 			-R /etc/pkg \


### PR DESCRIPTION
A few cleanup operations for the ISO:
* Exclude the "-profile" base packages from being *installed* on the ISO.
* Add a "prune-dist-packages" set of package lists which will be used for removing dist files from the ISO.
   * Each entry is treated as a basic regex (case-insensitive)
   * This will remove the matched files, but may leave dependencies of those package files behind.
   * Each entry automatically ends in "*.txz" so an entry can have the form "packagename" or "packagename-" instead of "packagename-*.txz"

Closes #196 while expanding its scope to also allow pruning non-base packages from the ISO as well.