### PR TITLE
ISO install base-package filtering

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -109,6 +109,9 @@ The "iso" target within the manifest controls all the options specific to creati
 * "iso-packages" (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
    * "default" (JSON array of strings) : Default list (required)
    * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "ignore-base-packages" (JSON array of strings) : List of base packages to ignore when installing base packages into the ISO. 
+   * This is turned into a regex automatically, so "-clang-" will remove all forms of the clang package, but "-clang-development" will only ignore the development package for clang.
+   * **WARNING** Do *NOT* ignore the "runtime" package - this will typically break the ability of the ISO to start up.
 * "auto-install-packages" (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer.
    * **NOTE:** These packages will automatically get added to the "dist-packages" available on the ISO as well.
    * "default" (JSON array of strings) : Default list (required)
@@ -152,6 +155,10 @@ The "iso" target within the manifest controls all the options specific to creati
       "/usr/local/include"
     ]
   },
+  "ignore-base-packages": [
+    "-clang-",
+    "-sendmail-"
+  ],
   "iso-packages": {
     "default": [
       "sysutils/ipmitool",

--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -686,7 +686,7 @@ EOF
 	fi
 	# Check for explict pkgs to install, minus development, debug, and profile
 	echo "Installing base packages into ISO:"
-	for e in $(get_explicit_pkg_deps "development debug profile")
+	for e in $(get_explicit_pkg_deps )
 	do
 		#Filter out any designated base packages
 		if [ -n "${_base_ignore}" ] ; then

--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -679,9 +679,24 @@ EOF
 	chroot ${OBJDIR}/disc1 cap_mkdb /etc/login.conf
 	touch ${OBJDIR}/disc1/etc/fstab
 
+	# Assemble the list of base packages to ignore (as a Regex)
+	local _base_ignore=""
+	if [ "$(jq -r '."iso"."ignore-base-packages" | length' ${TRUEOS_MANIFEST})" != "0" ] ; then
+		_base_ignore=`jq -r '."iso".""ignore-base-packages" | join("|")' ${TRUEOS_MANIFEST}`
+	fi
 	# Check for explict pkgs to install, minus development, debug, and profile
+	echo "Installing base packages into ISO:"
 	for e in $(get_explicit_pkg_deps "development debug profile")
 	do
+		#Filter out any designated base packages
+		if [ -n "${_base_ignore}" ] ; then
+		  #have packages to ignore - see if this one matches
+		  echo "${e}" | grep -qiE "(${_base_ignore})"
+		  if [ $? -eq 0 ] ; then
+		    echo "Ignoring base package: ${e}"
+		    continue
+		  fi
+		fi
 		pkg-static -o ABI_FILE=/bin/sh \
 			-R /etc/pkg \
 			-c ${OBJDIR}/disc1 \


### PR DESCRIPTION
Add the ability to specify a list of packages to ignore when installing base packages into the ISO.
"iso" -> "ignore-base-packages" (JSON Array of strings)
 * This is automatically assembled into a filter list (regex), so an entries of the form: "-clang-", "-clang-development-", or even "-profile-" should work just fine.