### PR TITLE
Allow custom distro branding in pc-installdialog

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -32,6 +32,16 @@ This document corresponds to version "1.0", so any manifest using this specifica
 
 `"version" : "1.0"`
 
+### Distribution Branding
+There are a couple options which may be set in the manifest in order to "brand" the distribution of TrueOS.
+
+* "os_name" (string) : Branding name for the distribution.
+   * Default Value: "TrueOS"
+   * Will change the branding in pc-installdialog, and the distro branding in the bootloader as well.
+* "os_version" (string) : Custom version tag for the build. 
+   * At build time this will become the "TRUEOS_VERSION" environment variable which can be used in filename expansions and such later (if that environment variable is not already set).
+
+
 ### base-packages
 The "base-packages" target allows the configuration of the OS packages itself. This can involve the naming scheme, build flags, extra dependencies, and more.
 

--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -63,6 +63,9 @@ env_check()
 	PORTS_URL=$(jq -r '."ports"."url"' $TRUEOS_MANIFEST)
 	PORTS_BRANCH=$(jq -r '."ports"."branch"' $TRUEOS_MANIFEST)
 
+	if [ -z "${TRUEOS_VERSION}" ] ; then
+		TRUEOS_VERSION=$(jq -r '."os_version"' $TRUEOS_MANIFEST)
+	fi
 	case $PORTS_TYPE in
 		git) if [ -z "$PORTS_BRANCH" ] ; then
 			exit_err "Empty ports.branch!"

--- a/usr.sbin/pc-installdialog/pc-installdialog.sh
+++ b/usr.sbin/pc-installdialog/pc-installdialog.sh
@@ -5,8 +5,16 @@
 # This script is fairly linear, it will walk through a series of questions
 # and when finished, generate a pc-sysinstall script
 
+#See if this is a branded bootup and use that name
+BRAND="TrueOS"
+if [ -e "/var/db/trueos-manifest.json" ] ; then
+  _tmp=`jq -r '."os_name"' "/var/db/trueos-manifest.json"`
+  if [ -n "${_tmp}" ] ; then 
+    BRAND="${_tmp}"
+  fi
+fi
 # Dialog menu title
-TITLE="TrueOS Install Dialog"
+TITLE="${BRAND} Install Dialog"
 
 # pc-sysinstall config file to write out to
 CFGFILE="/tmp/sys-install.cfg"
@@ -992,7 +1000,7 @@ start_edit_menu_loop()
 
   while :
   do
-    dialog --title "TrueOS Text Install - Edit Menu" --menu "Please select from the following options:" 18 70 10 disk "Change disk ($SYSDISK)" pool "ZFS pool layout" datasets "ZFS datasets" zpoolcfg "ZFS Pool Config" network "Change networking" view "View install script" edit "Edit install script" back "Back to main menu" 2>/tmp/answer
+    dialog --title "${BRAND} Text Install - Edit Menu" --menu "Please select from the following options:" 18 70 10 disk "Change disk ($SYSDISK)" pool "ZFS pool layout" datasets "ZFS datasets" zpoolcfg "ZFS Pool Config" network "Change networking" view "View install script" edit "Edit install script" back "Back to main menu" 2>/tmp/answer
     if [ $? -ne 0 ] ; then break ; fi
 
     ANS="`cat /tmp/answer`"
@@ -1026,7 +1034,7 @@ start_menu_loop()
 
   while :
   do
-    dialog --title "TrueOS Text Install" --menu "Please select from the following options:" 18 40 10 install "Start the installation" wizard "Re-run install wizard" edit "Edit install options" hardware "check compatibility" quit "Quit install wizard" 2>/tmp/answer
+    dialog --title "${BRAND} Text Install" --menu "Please select from the following options:" 18 40 10 install "Start the installation" wizard "Re-run install wizard" edit "Edit install options" hardware "check compatibility" quit "Quit install wizard" 2>/tmp/answer
     if [ $? -ne 0 ] ; then break ; fi
 
     ANS="`cat /tmp/answer`"


### PR DESCRIPTION
Have it support an "os_name" variable in the trueos-manifest JSON config file used to create the distro.
Will use "TrueOS" as the default name if that variable/file does not exist (just like before).