### PR TITLE
trueos-stable ISO slimming options

### DIFF
--- a/release/manifests/trueos-stable.json
+++ b/release/manifests/trueos-stable.json
@@ -32,6 +32,12 @@
         "sysutils/tmux"
       ]
     },
+    "prune-dist-packages" : {
+      "default" : [
+        "(TrueOS-).+(-profile-)",
+        "(TrueOS-).+(-debug-)"
+      ]
+    },
     "install-script": "",
     "iso-packages": {
       "default": [
@@ -40,6 +46,21 @@
         "sysutils/tmux"
       ]
     },
+    "ignore-base-packages": [
+      "-clang-",
+      "-gdb-",
+      "-lldb-",
+      "-ipf-",
+      "-pf-",
+      "-sendmail-",
+      "-ssh-",
+      "-svn-",
+      "-unbound-",
+      "-tests",
+      "-development",
+      "-profile",
+      "-debug"
+    ],
     "overlay": ""
   },
   "pkg-repo": {


### PR DESCRIPTION
Slim down the ISO for STABLE builds in the following ways:
1. Distfiles (those that will get installed into the system: "prune-dist-packages")
   * Remove "*-profile" and "*-debug" base packages
2. Packages installed into the ISO itself ("ignore-base-packages"). These will still be installed onto the system normally.
   * Skip all the compiler/development packages (clang, gdb, lldb, development, profile, debug)
   * Skip a lot of networking related runtime packages (ipf, pf, sendmail, ssh, svn, unbound)
   * Skip the self tests (tests)