### PR TITLE
Update cleanvar

### DIFF
--- a/libexec/rc/etc.init.d/cleanvar
+++ b/libexec/rc/etc.init.d/cleanvar
@@ -54,13 +54,13 @@ start_pre()
 
 start()
 {
-        if [ -d /var/run -a ! -f /var/run/clean_var ]; then
-                purgedir /var/run
-                >/var/run/clean_var
-        fi
-        if [ -d /var/spool/lock -a ! -f /var/spool/lock/clean_var ]; then
-                purgedir /var/spool/lock
-                >/var/spool/lock/clean_var
-        fi
+	local dirlist="/var/run /var/spool/lock /var/tmp"
+	for _dir in ${dirlist}
+	do
+        	if [ -d ${_dir} -a ! -f ${_dir}/clean_var ]; then
+                	purgedir ${_dir}
+                	>${_dir}/clean_var
+        	fi	
+	done
         rm -rf /var/spool/uucp/.Temp/*
 }


### PR DESCRIPTION
Instead of copying the if statment for "every" directory, just make a list of the directories and loop over them with the same routine.
Also add /var/tmp to the cleanup list.

This should also be backported to the trueos-stable-18.12 branch as well.