### PR TITLE
Fix origin for networkmgr

### DIFF
--- a/release/manifests/trueos-gnome.json
+++ b/release/manifests/trueos-gnome.json
@@ -61,7 +61,7 @@
 			"mail/thunderbird",
 			"www/firefox",
 			"www/chromium",
-			"sysutils/networkmgr",
+			"net-mgmt/networkmgr",
 			"sysutils/tmux",
 			"x11/gnome3-lite",
 			"deskutils/gucharmap",


### PR DESCRIPTION
This fixes origin for networkmgr.  I expected that pkg build would fail if origin name would wrong.  Instead it fails when it attempts to install the packages during the installer.  I have a seperate larger PR coming for stable to fix ISO name, and train in manifest in addition to including this fix.