### PR TITLE
Gnome manifest fix stable and fix pkg origin

### DIFF
--- a/release/manifests/trueos-gnome.json
+++ b/release/manifests/trueos-gnome.json
@@ -44,7 +44,7 @@
 	  "NOHANG_TIME=14400"
   ],
   "iso":{
-	"file-name":"TrueOS-Gnome-Unstable-x64-%%GITHASH%%-%%DATE%%",
+	"file-name":"TrueOS-Gnome-Stable-x64-%%GITHASH%%-%%DATE%%",
 	"iso-packages":{
 		  "default":[
 			"sysutils/tmux"
@@ -131,7 +131,7 @@
           }
   },
   "pkg-repo": {
-	  "url":"https://pkg.trueos.org/pkg/gnome-unstable/${ABI}/latest",
+	  "url":"https://pkg.trueos.org/pkg/gnome-stable/${ABI}/latest",
 	  "pubKey": [
 		"-----BEGIN PUBLIC KEY-----",
 		"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAx4YxSavJkE7HjopkMtgK",
@@ -150,5 +150,5 @@
 	  ]
   },
   "pkg-repo-name": "TrueOS",
-  "pkg-train-name": "gnome-unstable"
+  "pkg-train-name": "gnome-stable"
 }

--- a/release/manifests/trueos-gnome.json
+++ b/release/manifests/trueos-gnome.json
@@ -61,7 +61,7 @@
 			"mail/thunderbird",
 			"www/firefox",
 			"www/chromium",
-			"sysutils/networkmgr",
+			"net-mgmt/networkmgr",
 			"sysutils/tmux",
 			"x11/gnome3-lite",
 			"deskutils/gucharmap",


### PR DESCRIPTION
This fixes:

* pkg origin for networkmgr
* iso name for stable
* train name for stable