### PR TITLE
No clang 6.0.1 headers after Trident 18.12 PreRelease-2 Upgrade

### DIFF
--- a/usr.bin/compiler-bootstrap/compiler-bootstrap.sh
+++ b/usr.bin/compiler-bootstrap/compiler-bootstrap.sh
@@ -29,7 +29,7 @@
 #  SUCH DAMAGE.
 
 # Script to go through and create sym-links to ports version of LLVM
-DEFAULT_LLVM=llvm60
+DEFAULT_LLVM=llvm70
 
 if [ -z "${TRUEOS_MANIFEST}" ] ; then
 	BASEDIR="/usr/local"


### PR DESCRIPTION
When upgraded to Trident 18.12 PreRelease-2 build  the clang 6.0.1 include directory looks purged. So any attempt to compile witih clang 6.0.1 yields compilation errors such as "x86intrin.h not found"

The compilation was successful after explicitly invoking compiler-bootstrap llvm70

So it seems clang was upgraded from 6 to 7 and the prior version was purged from packages.

Can anyone please confirm this?

> $ ls -lrt /usr/lib/clang/6.0.1/include/
> total 1
> drwxr-xr-x  2 root  wheel  2 Dec 30 21:04 sanitizer