### PR TITLE
Update the way we parse world flags and kernel flags,

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,38 +106,6 @@
 #
 # For more information, see the build(7) manual page.
 
-# Check if TRUEOS_MANIFEST is set, if not use the default
-.if !defined(TRUEOS_MANIFEST)
-TRUEOS_MANIFEST=	${.CURDIR}/release/trueos-manifest.json
-.endif
-
-# Confirm the file TRUEOS_MANIFEST exists
-.if !exists(${TRUEOS_MANIFEST})
-.error "Missing file TRUEOS_MANIFEST: ${TRUEOS_MANIFEST}"
-.endif
-
-# Validate the version of this manifest and sanity check environment
-.if make(buildworld) || make(buildkernel) || make(packages)
-TM_VERCHECK!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${.CURDIR}/release/release-trueos.sh check >&2 ; echo $$?)
-.if ${TM_VERCHECK} != "0"
-.error Failed environment sanity check!
-.endif
-.endif
-
-# Set any world/kernel flags from our manifest
-TO_WFLAGS!=		/usr/local/bin/jq -r '."base-packages"."world-flags"' \
-				${TRUEOS_MANIFEST}
-.if ${TO_WFLAGS} != "null"
-TO_WFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${.CURDIR}/release/release-trueos.sh world_flags /tmp/.wflags.${.MAKE.PID})
-.include "/tmp/.wflags.${.MAKE.PID}"
-.endif
-TO_KFLAGS!=		/usr/local/bin/jq -r '."base-packages"."kernel-flags"' \
-				${TRUEOS_MANIFEST}
-.if ${TO_KFLAGS} != "null"
-TO_KFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${.CURDIR}/release/release-trueos.sh kernel_flags /tmp/.kflags.${.MAKE.PID})
-.include "/tmp/.kflags.${.MAKE.PID}"
-.endif
-
 # This is included so CC is set to ccache for -V, and COMPILER_TYPE/VERSION
 # can be cached for sub-makes. We can't do this while still running on the
 # old fmake from FreeBSD 9.x or older, so avoid including it then to avoid

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -84,30 +84,6 @@ PKG_BASENAME!=		/usr/bin/jq -r '."base-packages"."name-prefix"' \
 .endif
 .endif
 
-# Validate the version of this manifest and sanity check environment
-.if make(buildworld) || make(buildkernel) || make(packages)
-TM_VERCHECK!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release-trueos.sh check >&2 ; echo $$?)
-.if ${TM_VERCHECK} != "0"
-.error Failed environment sanity check!
-.endif
-.endif
-
-# Set any world/kernel flags from our manifest
-TO_WFLAGS!=		/usr/local/bin/jq -r '."base-packages"."world-flags"' \
-				${TRUEOS_MANIFEST}
-.if ${TO_WFLAGS} != "null"
-TO_WFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release-trueos.sh world_flags /tmp/.wflags.${.MAKE.PID})
-.include "/tmp/.wflags.${.MAKE.PID}"
-TO_WFLAGS!=	(rm /tmp/.wflags.${.MAKE.PID})
-.endif
-TO_KFLAGS!=		/usr/local/bin/jq -r '."base-packages"."kernel-flags"' \
-				${TRUEOS_MANIFEST}
-.if ${TO_KFLAGS} != "null"
-TO_KFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release-trueos.sh kernel_flags /tmp/.kflags.${.MAKE.PID})
-.include "/tmp/.kflags.${.MAKE.PID}"
-TO_KFLAGS!=	(rm /tmp/.kflags.${.MAKE.PID})
-.endif
-
 # Cross toolchain changes must be in effect before bsd.compiler.mk
 # so that gets the right CC, and pass CROSS_TOOLCHAIN to submakes.
 .if defined(CROSS_TOOLCHAIN)

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -93,8 +93,20 @@ TM_VERCHECK!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release
 .endif
 
 # Set any world/kernel flags from our manifest
-WORLD_FLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release-trueos.sh world_flags)
-KERNEL_FLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release-trueos.sh kernel_flags)
+TO_WFLAGS!=		/usr/local/bin/jq -r '."base-packages"."world-flags"' \
+				${TRUEOS_MANIFEST}
+.if ${TO_WFLAGS} != "null"
+TO_WFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release-trueos.sh world_flags /tmp/.wflags.${.MAKE.PID})
+.include "/tmp/.wflags.${.MAKE.PID}"
+TO_WFLAGS!=	(rm /tmp/.wflags.${.MAKE.PID})
+.endif
+TO_KFLAGS!=		/usr/local/bin/jq -r '."base-packages"."kernel-flags"' \
+				${TRUEOS_MANIFEST}
+.if ${TO_KFLAGS} != "null"
+TO_KFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${SRCDIR}/release/release-trueos.sh kernel_flags /tmp/.kflags.${.MAKE.PID})
+.include "/tmp/.kflags.${.MAKE.PID}"
+TO_KFLAGS!=	(rm /tmp/.kflags.${.MAKE.PID})
+.endif
 
 # Cross toolchain changes must be in effect before bsd.compiler.mk
 # so that gets the right CC, and pass CROSS_TOOLCHAIN to submakes.

--- a/libexec/rc/etc.init.d/Makefile
+++ b/libexec/rc/etc.init.d/Makefile
@@ -4,10 +4,12 @@ PACKAGE=runtime
 
 .include <src.opts.mk>
 
-FILEDIR=	/etc/init.d
-FILEGROUP=	FILES
+NO_OBJ=
 
-FILES=          abi accounting adjkerntz amd apm apmd archdep auditd auditdistd automount \
+FILESDIR=	/etc/init.d
+FILESMODE=	755
+
+FILES+=          abi accounting adjkerntz amd apm apmd archdep auditd auditdistd automount \
 		automountd autounmountd \
 		bgfsck blacklistd bluetooth bootmisc bootparams bridge bsnmpd bthidd \
 		ccd cfumass cleanvar cleartmp cron ctld \
@@ -26,12 +28,7 @@ FILES=          abi accounting adjkerntz amd apm apmd archdep auditd auditdistd 
 		var watchdogd wpa_supplicant \
 		ypbind ypldap yppasswdd ypserv ypset ypupdated ypxfrd \
 		zfs zfsd zvol
-FILESMODE=	755
 
 LINKS=		/libexec/rc/sh/functions.sh /etc/init.d/functions.sh
-
-.for fg in ${FILEGROUPS}
-${fg}MODE?=	${BINMODE}
-.endfor
 
 .include <bsd.prog.mk>

--- a/release/Makefile
+++ b/release/Makefile
@@ -76,9 +76,21 @@ VOLUME_LABEL=	${REVISION:C/[.-]/_/g}_${BRANCH:C/[.-]/_/g}_${TARGET_ARCH}
 .endfor
 .endif
 
-# Get world / kernel flags for staging
-WORLD_FLAGS!=	(env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${WORLDDIR}/release/release-trueos.sh world_flags)
-KERNEL_FLAGS!=	(env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${WORLDDIR}/release/release-trueos.sh kernel_flags)
+# Set any world/kernel flags from our manifest
+TO_WFLAGS!=		/usr/local/bin/jq -r '."base-packages"."world-flags"' \
+				${TRUEOS_MANIFEST}
+.if ${TO_WFLAGS} != "null"
+TO_WFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${WORLDDIR}/release/release-trueos.sh world_flags /tmp/.wflags.${.MAKE.PID})
+.include "/tmp/.wflags.${.MAKE.PID}"
+TO_WFLAGS!=	(rm /tmp/.wflags.${.MAKE.PID})
+.endif
+TO_KFLAGS!=		/usr/local/bin/jq -r '."base-packages"."kernel-flags"' \
+				${TRUEOS_MANIFEST}
+.if ${TO_KFLAGS} != "null"
+TO_KFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${WORLDDIR}/release/release-trueos.sh kernel_flags /tmp/.kflags.${.MAKE.PID})
+.include "/tmp/.kflags.${.MAKE.PID}"
+TO_KFLAGS!=	(rm /tmp/.kflags.${.MAKE.PID})
+.endif
 
 .if !defined(VOLUME_LABEL) || empty(VOLUME_LABEL)
 VOLUME_LABEL=	TrueOS_Install

--- a/release/release-trueos.sh
+++ b/release/release-trueos.sh
@@ -58,7 +58,7 @@ env_check()
 	if [ -z "$TRUEOS_MANIFEST" ] ; then
 		exit_err "Unset TRUEOS_MANIFEST"
 	fi
-	echo "Using TRUEOS_MANIFEST: $TRUEOS_MANIFEST" >&2
+	#echo "Using TRUEOS_MANIFEST: $TRUEOS_MANIFEST" >&2
 	PORTS_TYPE=$(jq -r '."ports"."type"' $TRUEOS_MANIFEST)
 	PORTS_URL=$(jq -r '."ports"."url"' $TRUEOS_MANIFEST)
 	PORTS_BRANCH=$(jq -r '."ports"."branch"' $TRUEOS_MANIFEST)
@@ -819,6 +819,14 @@ check_build_environment()
 
 get_world_flags()
 {
+	if [ -z "$1" ] ; then
+		echo "Missing world flag include temp file location"
+		exit 1
+	fi
+
+	echo "" > $1
+	touch $1
+
 	# Check if we have any world-flags to pass back
 	for c in $(jq -r '."base-packages"."world-flags" | keys[]' ${TRUEOS_MANIFEST} 2>/dev/null | tr -s '\n' ' ')
 	do
@@ -826,15 +834,21 @@ get_world_flags()
 		if [ -z "$CHECK" -a "$c" != "default" ] ; then continue; fi
 		for i in $(jq -r '."base-packages"."world-flags"."'$c'" | join(" ")' ${TRUEOS_MANIFEST})
 		do
-			WF="$WF ${i}"
+			echo "$i" >> $1
 		done
 	done
-
-	echo "$WF"
 }
 
 get_kernel_flags()
 {
+	if [ -z "$1" ] ; then
+		echo "Missing kernel flag include temp file location"
+		exit 1
+	fi
+
+	echo "" > $1
+	touch $1
+
 	# Check if we have any kernel-flags to pass back
 	for c in $(jq -r '."base-packages"."kernel-flags" | keys[]' ${TRUEOS_MANIFEST} 2>/dev/null | tr -s '\n' ' ')
 	do
@@ -842,11 +856,9 @@ get_kernel_flags()
 		if [ -z "$CHECK" -a "$c" != "default" ] ; then continue; fi
 		for i in $(jq -r '."base-packages"."kernel-flags"."'$c'" | join(" ")' ${TRUEOS_MANIFEST})
 		do
-			WF="$WF ${i}"
+			echo "$i" >> $1
 		done
 	done
-
-	echo "$WF"
 }
 
 env_check
@@ -863,8 +875,8 @@ case $1 in
 	     ;;
 	check)  check_build_environment
 		check_version ;;
-	world_flags) get_world_flags ;;
-	kernel_flags) get_kernel_flags ;;
+	world_flags) get_world_flags "$2" ;;
+	kernel_flags) get_kernel_flags "$2" ;;
 	*) echo "Unknown option selected" ;;
 esac
 

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -2,6 +2,7 @@
 # $FreeBSD$
 
 # Check if TRUEOS_MANIFEST is set, if not use the default
+.if exists(${.CURDIR}/release/release-trueos.sh)
 .if !defined(TRUEOS_MANIFEST)
 TRUEOS_MANIFEST=	${.CURDIR}/release/trueos-manifest.json
 .endif
@@ -31,6 +32,7 @@ TO_KFLAGS!=		/usr/local/bin/jq -r '."base-packages"."kernel-flags"' \
 .if ${TO_KFLAGS} != "null"
 TO_KFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${.CURDIR}/release/release-trueos.sh kernel_flags /tmp/.kflags.${.MAKE.PID})
 .include "/tmp/.kflags.${.MAKE.PID}"
+.endif
 .endif
 
 unix		?=	We run FreeBSD, not UNIX.

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -1,6 +1,38 @@
 #	from: @(#)sys.mk	8.2 (Berkeley) 3/21/94
 # $FreeBSD$
 
+# Check if TRUEOS_MANIFEST is set, if not use the default
+.if !defined(TRUEOS_MANIFEST)
+TRUEOS_MANIFEST=	${.CURDIR}/release/trueos-manifest.json
+.endif
+
+# Confirm the file TRUEOS_MANIFEST exists
+.if !exists(${TRUEOS_MANIFEST})
+.error "Missing file TRUEOS_MANIFEST: ${TRUEOS_MANIFEST}"
+.endif
+
+# Validate the version of this manifest and sanity check environment
+.if make(buildworld) || make(buildkernel) || make(packages)
+TM_VERCHECK!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${.CURDIR}/release/release-trueos.sh check >&2 ; echo $$?)
+.if ${TM_VERCHECK} != "0"
+.error Failed environment sanity check!
+.endif
+.endif
+
+# Set any world/kernel flags from our manifest
+TO_WFLAGS!=		/usr/local/bin/jq -r '."base-packages"."world-flags"' \
+				${TRUEOS_MANIFEST}
+.if ${TO_WFLAGS} != "null"
+TO_WFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${.CURDIR}/release/release-trueos.sh world_flags /tmp/.wflags.${.MAKE.PID})
+.include "/tmp/.wflags.${.MAKE.PID}"
+.endif
+TO_KFLAGS!=		/usr/local/bin/jq -r '."base-packages"."kernel-flags"' \
+				${TRUEOS_MANIFEST}
+.if ${TO_KFLAGS} != "null"
+TO_KFLAGS!=	 (env TRUEOS_MANIFEST=${TRUEOS_MANIFEST} ${.CURDIR}/release/release-trueos.sh kernel_flags /tmp/.kflags.${.MAKE.PID})
+.include "/tmp/.kflags.${.MAKE.PID}"
+.endif
+
 unix		?=	We run FreeBSD, not UNIX.
 .FreeBSD	?=	true
 


### PR DESCRIPTION
lets try and set them much earlier in Makefile, and more
importantly in share/mk/sys.mk so that they get picked up
before the WITH_* -> MK_* parsing takes place.

This fixes #261