### PR TITLE
Fix devmatch config to be in-line with its current rc script

### DIFF
--- a/libexec/rc/rc.devd
+++ b/libexec/rc/rc.devd
@@ -29,7 +29,7 @@ getmedia() {
 # Try and create an init script for network interfaces
 base=${1%%.*}
 if [ "${base}" = "network" ]; then
-	# We only create links for pyhsical interfaces
+	# We only create links for physical interfaces
 	[ -n "$(getmedia ${1#*.})" ] || exit 1
 	base="network.lo0"
 fi

--- a/sbin/devd/devmatch-openrc.conf
+++ b/sbin/devd/devmatch-openrc.conf
@@ -9,7 +9,7 @@
 #
 # Generic NOMATCH event
 nomatch 100 {
-	action "sh /etc/rc.devd devmatch start.'?'$_ '?'$_";
+       action "/etc/rc.d/devmatch quietstart '?'$_";
 };
 
 # Add the following to devd.conf to prevent this from running:

--- a/sbin/devd/devmatch-openrc.conf
+++ b/sbin/devd/devmatch-openrc.conf
@@ -9,7 +9,7 @@
 #
 # Generic NOMATCH event
 nomatch 100 {
-       action "/etc/rc.d/devmatch quietstart '?'$_";
+	action "sh /etc/rc.devd devmatch start.'?'$_ '?'$_";
 };
 
 # Add the following to devd.conf to prevent this from running:

--- a/sbin/devd/devmatch.conf
+++ b/sbin/devd/devmatch.conf
@@ -9,7 +9,11 @@
 #
 # Generic NOMATCH event
 nomatch 100 {
-	action "service devmatch quietstart '?'$_";
+#FIXME: /sbin/service has not yet been updated to support devd -> devmatch events
+#	Once it is patched from FreeBSD upstream below can be switched back to using /sbin/service
+#	Please see ticket https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=235257 for more details
+#	action "service devmatch quietstart '?'$_";
+        action "/etc/rc.d/devmatch quietstart '?'$_";
 };
 
 # Add the following to devd.conf to prevent this from running:


### PR DESCRIPTION
Please see FreeBSD the following tickets for more details
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=235257
https://github.com/project-trident/trident-core/issues/63

I was able tested it on my machine and confirmed that when USB device was attached the devd nomatch  event triggered devmatch to load respective module (when running devd in foreground)

When testing the trigger on startup I found the modules are still not autoloaded. This seems to be because USB devices are attached much earlier than devd daemon starts up. I followed up with this question on FreeBSD bugtracker.
