### PR TITLE
rename tank to zroot

### DIFF
--- a/usr.sbin/pc-installdialog/pc-installdialog.sh
+++ b/usr.sbin/pc-installdialog/pc-installdialog.sh
@@ -44,7 +44,7 @@ PIJSON="/root/post-install-commands.json"
 SWAPSIZE="2000"
 
 # Default boot pool name
-POOLNAME="tank"
+POOLNAME="zroot"
 
 # Set location of default TrueOS Manifest
 TRUEOS_MANIFEST="/root/trueos-manifest.json"


### PR DESCRIPTION
- We want to standardize that with FreeBSD, also its easier to adopt for FreeBSD's native tools and configs such as poudriere.