### PR TITLE
Change default swap from 2GB to 4GB

### DIFF
--- a/usr.sbin/pc-installdialog/pc-installdialog.sh
+++ b/usr.sbin/pc-installdialog/pc-installdialog.sh
@@ -41,7 +41,7 @@ ASHIFTSIZE="12"
 PIJSON="/root/post-install-commands.json"
 
 # Default swapsize in MB
-SWAPSIZE="2000"
+SWAPSIZE="4000"
 
 # Default boot pool name
 POOLNAME="tank"


### PR DESCRIPTION
Normal end user notebooks comes these days with 8/16 GB ram default, even thought it should be enough but building chrome as example can excite the 2GB of swap, increase to 4Gb gives at least a bit more room to survive.