### PR TITLE
add first user to video group

### DIFF
--- a/usr.sbin/pc-installdialog/pc-installdialog.sh
+++ b/usr.sbin/pc-installdialog/pc-installdialog.sh
@@ -965,7 +965,7 @@ gen_pc-sysinstall_cfg()
    echo "userPass=${USERPW}" >> ${CFGFILE}
    echo "userShell=${USERSHELL}" >> ${CFGFILE}
    echo "userHome=/home/${USERNAME}" >> ${CFGFILE}
-   echo "userGroups=wheel,operator" >> ${CFGFILE}
+   echo "userGroups=wheel,operator,video" >> ${CFGFILE}
    echo "commitUser" >> ${CFGFILE}
 
    # Last cleanup stuff


### PR DESCRIPTION
For Desktop users its a must to be in the video group, to make it easier for installing nvidia/intel drivers add the the first user to the video group