### PR TITLE
use vi instance of ee

### DIFF
--- a/usr.sbin/pc-installdialog/pc-installdialog.sh
+++ b/usr.sbin/pc-installdialog/pc-installdialog.sh
@@ -1059,7 +1059,7 @@ start_edit_menu_loop()
        view) more ${CFGFILE}
              rtn
              ;;
-       edit) ee ${CFGFILE}
+       edit) vi ${CFGFILE}
              rtn
              ;;
        back) break ;;


### PR DESCRIPTION
When we run custom iso's with ee editor disable we are not able to edit the config file anymore, use vi makes more sense and pplz where want to change the config usually know how to use vi :-)