### PR TITLE
Remove zfs from FreeNAS kernel conf

### DIFF
--- a/sys/amd64/conf/IXNAS
+++ b/sys/amd64/conf/IXNAS
@@ -401,7 +401,6 @@ options		UNIONFS			# Union filesystem
 options		TMPFS			# Efficient memory filesystem
 options		ISP_TARGET_MODE		# Qlogic FC target mode
 options		COMPAT_LINUXKPI
-device		zfs
 device		coretemp
 device		cpuctl
 device		cryptodev		# /dev/crypto for access to h/w


### PR DESCRIPTION
This commit removes zfs from FreeNAS kernel conf.