### PR TITLE
Openrc service fixes

### DIFF
--- a/contrib/openrc/etc/devd.conf
+++ b/contrib/openrc/etc/devd.conf
@@ -101,11 +101,11 @@ detach 100 {
 # When a USB Bluetooth dongle appears activate it
 attach 100 {
 	device-name "ubt[0-9]+";
-	action "/etc/rc.d/bluetooth start $device-name";
+	action "/etc/rc.devd bluetooth.$device-name start";
 };
 detach 100 {
 	device-name "ubt[0-9]+";
-	action "/etc/rc.d/bluetooth stop $device-name";
+	action "/etc/rc.devd bluetooth.$device-name stop";
 };
 
 # When a USB keyboard arrives, attach it as the console keyboard.

--- a/libexec/rc/etc.init.d/devmatch
+++ b/libexec/rc/etc.init.d/devmatch
@@ -34,15 +34,15 @@ one_nomatch="$devd_args"
 
 start()
 {
-	local x
+	local x m list
 
 	if [ -n "$one_nomatch" ]; then
-		x=$(devmatch -p "${one_nomatch}")
+		list=$(devmatch -p "${one_nomatch}" | sort -u)
 	else
-		x=$(devmatch)
+		list=$(devmatch | sort -u)
 	fi
 
-	[ -n "$x" ] || return
+	[ -n "$list" ] || return
 
 	# While kldload can accept multiple modules
 	# on the line at once, we loop here in case
@@ -50,10 +50,18 @@ start()
 	# We also optimize against the false positives
 	# or drivers that have symbolic links that
 	# confuse devmatch by running it -n.
-	for m in ${x}; do
+	# Finally, we filter out all items in the
+	# devmactch_blacklist.
+	devctl freeze
+	x=$(echo ${devmatch_blacklist} | tr ' ' '#')
+	for m in ${list}; do
+		case "#${x}#" in
+		*"#${m}#"*) continue ;;
+		esac
 		einfo "Autoloading module: ${m}"
 		kldload -n ${m}
 	done
+	devctl thaw
 	return 0
 }
 


### PR DESCRIPTION
A few quick fixes for some OpenRC services/configs.
1. devd-openrc.conf
   * Ensure we use rc.devd to launch the OpenRC version of the bluetooth service, not the rc.d version.
2. Resync the "devmatch" openrc service with the upstream rc.d version. They apparently added device blacklisting in the rc.d service, as well as some kind of "freeze/thaw" interaction with devctl.