### PR TITLE
Re-add a missing patch to ensure that the "service" script redirects …

### DIFF
--- a/usr.sbin/service/service.sh
+++ b/usr.sbin/service/service.sh
@@ -28,6 +28,12 @@
 #  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 #  SUCH DAMAGE.
 
+# Are we using OpenRC instead of RC?
+if [ "$(/bin/kenv rc_system 2>/dev/null)" = "openrc" ]; then
+   /sbin/rc-service ${@}
+   exit $?
+fi
+
 . /etc/rc.subr
 load_rc_config 'XXX'
 


### PR DESCRIPTION
…to "rc-service" if OpenRC is used.

TOS-287 #in-review