### PR TITLE
- Restore: 5be7ff

### DIFF
--- a/usr.sbin/autofs/autounmountd.8
+++ b/usr.sbin/autofs/autounmountd.8
@@ -27,7 +27,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd December 13, 2014
+.Dd June 26, 2019
 .Dt AUTOUNMOUNTD 8
 .Os
 .Sh NAME
@@ -56,6 +56,8 @@ attempts to unmount a filesystem, retrying after some time if necessary.
 .Pp
 These options are available:
 .Bl -tag -width ".Fl v"
+.It Fl D
+Do not daemonize.
 .It Fl d
 Debug mode: increase verbosity and do not daemonize.
 .It Fl r

--- a/usr.sbin/autofs/autounmountd.c
+++ b/usr.sbin/autofs/autounmountd.c
@@ -271,7 +271,7 @@ main_autounmountd(int argc, char **argv)
 	double expiration_time = 600, retry_time = 600, mounted_max, sleep_time;
 	bool dont_daemonize = false;
 
-	while ((ch = getopt(argc, argv, "dr:t:v")) != -1) {
+	while ((ch = getopt(argc, argv, "dr:t:vD")) != -1) {
 		switch (ch) {
 		case 'd':
 			dont_daemonize = true;
@@ -285,6 +285,9 @@ main_autounmountd(int argc, char **argv)
 			break;
 		case 'v':
 			debug++;
+			break;
+		case 'D':
+			dont_daemonize = true;
 			break;
 		case '?':
 		default:


### PR DESCRIPTION
- autounmountd: Add a new CLI flag

-D: Do not daemonize
The current "-d" flag is a combination of -D (no daemon) and -v (debug mode)
but there was no way to prevent daemonization without verbose output.
Also change the OpenRC service over to use the new -D flag rather than -d