### PR TITLE
Add an "openrc_quiet" loader.conf option

### DIFF
--- a/libexec/rc/rc
+++ b/libexec/rc/rc
@@ -35,7 +35,11 @@ fi
 
 # Are we using OpenRC instead of RC?
 if [ "$(/bin/kenv rc_system 2>/dev/null)" = "openrc" ]; then
-   sh /etc/openrc
+   if [ "$(/bin/kenv openrc_quiet 2>/dev/null)" = "YES" ]; then
+     sh /etc/openrc --quiet
+   else
+     sh /etc/openrc
+   fi
    exit $?
 fi
 


### PR DESCRIPTION
If set to "YES", then openrc gets started up with the "--quiet" flag. (Option listed in the `openrc -h` options list)